### PR TITLE
X共有ポストをドラフト保存できるようにする

### DIFF
--- a/app/tweet-tagger/public/pwa-icon-192.svg
+++ b/app/tweet-tagger/public/pwa-icon-192.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="40" fill="#1976d2"/>
+  <rect x="30" y="30" width="132" height="132" rx="28" fill="#ffffff"/>
+  <path d="M57 67h78v16H57zm0 26h78v16H57zm0 26h49v16H57z" fill="#1976d2"/>
+  <circle cx="132" cy="127" r="17" fill="#ffb300"/>
+  <path d="M132 117v20m-10-10h20" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+</svg>

--- a/app/tweet-tagger/public/pwa-icon-512.svg
+++ b/app/tweet-tagger/public/pwa-icon-512.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="107" fill="#1976d2"/>
+  <rect x="80" y="80" width="352" height="352" rx="75" fill="#ffffff"/>
+  <path d="M152 179h208v43H152zm0 69h208v43H152zm0 69h131v43H152z" fill="#1976d2"/>
+  <circle cx="352" cy="339" r="45" fill="#ffb300"/>
+  <path d="M352 312v54m-27-27h54" stroke="#ffffff" stroke-width="19" stroke-linecap="round"/>
+</svg>

--- a/app/tweet-tagger/src/app/client-component/EventList.tsx
+++ b/app/tweet-tagger/src/app/client-component/EventList.tsx
@@ -55,11 +55,26 @@ const EventList = ({ refreshKey, onEdit }: { refreshKey: number; onEdit?: (event
 
     if (isLoading) return <CircularProgress size={24} />;
 
+    const snackbarElement = (
+        <Snackbar
+            open={snackbar.open}
+            autoHideDuration={3000}
+            onClose={() => setSnackbar((p) => ({ ...p, open: false }))}
+        >
+            <Alert severity={snackbar.severity} onClose={() => setSnackbar((p) => ({ ...p, open: false }))}>
+                {snackbar.message}
+            </Alert>
+        </Snackbar>
+    );
+
     if (events.length === 0) {
         return (
-            <Typography variant="body2" color="text.secondary">
-                登録済みイベントはありません
-            </Typography>
+            <>
+                <Typography variant="body2" color="text.secondary">
+                    登録済みイベントはありません
+                </Typography>
+                {snackbarElement}
+            </>
         );
     }
 
@@ -112,15 +127,7 @@ const EventList = ({ refreshKey, onEdit }: { refreshKey: number; onEdit?: (event
                 </Table>
             </TableContainer>
 
-            <Snackbar
-                open={snackbar.open}
-                autoHideDuration={3000}
-                onClose={() => setSnackbar((p) => ({ ...p, open: false }))}
-            >
-                <Alert severity={snackbar.severity} onClose={() => setSnackbar((p) => ({ ...p, open: false }))}>
-                    {snackbar.message}
-                </Alert>
-            </Snackbar>
+            {snackbarElement}
         </>
     );
 };

--- a/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TextField, Stack, Button, Checkbox, FormControlLabel, } from "@mui/material";
+import { Alert, TextField, Stack, Button, Checkbox, FormControlLabel, } from "@mui/material";
 import { useEffect, useState } from "react";
 import { DateTimeField } from "@mui/x-date-pickers/DateTimeField";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
@@ -8,7 +8,9 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { Tweet } from "../../components/tweet/swr";
 import dayjs, { Dayjs } from "dayjs";
 import { Cast, Post, PostCastTag } from "@iba-cast-gallery/dao";
+import { useRouter } from "next/navigation";
 import TagEditor from "./TagEditor";
+import { extractPostId } from "utils/postId";
 
 
 /**
@@ -22,6 +24,7 @@ const TweetEditor = ({ initialId }: {
 
   // 初期値がある場合は編集不可とする
   const isDisableTweetId = initialId !== undefined && initialId !== "";
+  const router = useRouter();
 
   const [casts, setCasts] = useState<Cast[]>([]);
 
@@ -48,6 +51,7 @@ const TweetEditor = ({ initialId }: {
   const [tweetDateTime, setTweetDateTime] = useState<Dayjs | null>(dayjs());
   const [isDeleted, setIsDeleted] = useState<boolean>(false);
   const [castTags, setCastTags] = useState<PostCastTag[]>([]);
+  const [showInGallery, setShowInGallery] = useState<boolean | null>(null);
 
   const registerTweet = async () => {
     if (tweetDateTime === null) return;
@@ -78,6 +82,14 @@ const TweetEditor = ({ initialId }: {
         return;
       }
 
+      setShowInGallery(true);
+
+      if (isDisableTweetId) {
+        router.push("/posts");
+        router.refresh();
+        return;
+      }
+
       // 登録完了で諸々リセット
       setTweetId("");
       setCastTags([]);
@@ -92,6 +104,7 @@ const TweetEditor = ({ initialId }: {
       const response = await fetch(`/api/posts/${tweetId}`);
 
       if (response.status === 404) {
+        setShowInGallery(null);
         return;
       }
 
@@ -110,6 +123,7 @@ const TweetEditor = ({ initialId }: {
       if (data.isDeleted !== undefined) {
         setIsDeleted(data.isDeleted);
       }
+      setShowInGallery(data.showInGallery);
     } catch (error) {
       console.error("Error fetch post:", error);
     }
@@ -117,9 +131,9 @@ const TweetEditor = ({ initialId }: {
 
   useEffect(() => {
     // URLからツイートIDを取得
-    const match = tweetId.match(/https:\/\/x\.com\/[^/]+\/status\/(\d+)/);
-    if (match) {
-      setTweetId(match[1]);
+    const postId = extractPostId(tweetId);
+    if (postId !== null && postId !== tweetId) {
+      setTweetId(postId);
       return;
     }
 
@@ -129,6 +143,11 @@ const TweetEditor = ({ initialId }: {
 
   return (
     <Stack className="w-full" direction="column" spacing={2} alignItems="left">
+      {showInGallery === false && (
+        <Alert severity="info" data-testid="draft-status">
+          ドラフト保存済みです。「ギャラリーに公開」を押すまで公開側には表示されません。
+        </Alert>
+      )}
       <TextField  slotProps={{ htmlInput: { 'data-testid': 'tweet-id-input' } }} fullWidth value={tweetId} onChange={(e) => setTweetId(e.target.value)} label="Tweet ID" variant="outlined" size="small" disabled={isDisableTweetId} />
       <Tweet id={tweetId} taggedCasts={[]} />
       <TagEditor casts={casts} castTags={castTags} setCastTags={setCastTags} />
@@ -136,7 +155,9 @@ const TweetEditor = ({ initialId }: {
         <DateTimeField format="YYYY/MM/DD HH:mm" label="ツイートの日時" ampm={false} value={tweetDateTime} onChange={(newValue) => setTweetDateTime(newValue)} />
       </LocalizationProvider>
       <FormControlLabel control={<Checkbox checked={isDeleted} onChange={(e, checked) => setIsDeleted(checked)} />} label="削除フラグ" />
-      <Button sx={{ marginTop: 1 }} variant="contained" color="primary" onClick={registerTweet} data-testid='tweet-register-button'> 登録</Button>
+      <Button sx={{ marginTop: 1 }} variant="contained" color="primary" onClick={registerTweet} data-testid='tweet-register-button'>
+        {showInGallery === false ? "ギャラリーに公開" : "登録"}
+      </Button>
     </Stack>
   );
 };

--- a/app/tweet-tagger/src/app/client-component/TweetList.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetList.tsx
@@ -2,7 +2,7 @@
 
 import { Post } from "@iba-cast-gallery/dao";
 import { Tweet } from "components/tweet/swr";
-import { Button, CircularProgress, Grid, Typography } from "@mui/material";
+import { Button, Chip, CircularProgress, Grid, Typography } from "@mui/material";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -50,6 +50,15 @@ const TweetList = () => {
             data-testid={`tweet-list-item-${index + 1}`}
           >
             <div className="border p-4 rounded">
+              {!post.showInGallery && (
+                <Chip
+                  label="ドラフト"
+                  color="warning"
+                  size="small"
+                  data-testid="draft-chip"
+                  sx={{ mb: 1 }}
+                />
+              )}
               {post.isDeleted ? (
                 <Typography variant="body2" color="error">
                   削除済み

--- a/app/tweet-tagger/src/app/manifest.webmanifest
+++ b/app/tweet-tagger/src/app/manifest.webmanifest
@@ -1,0 +1,35 @@
+{
+  "id": "/",
+  "name": "いばぎゃらりぃ管理画面",
+  "short_name": "いば管理",
+  "description": "いばぎゃらりぃのポストを登録・タグ付けする管理画面です",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1976d2",
+  "icons": [
+    {
+      "src": "/pwa-icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/pwa-icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "share_target": {
+    "action": "/share",
+    "method": "POST",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
+}

--- a/app/tweet-tagger/src/app/page.tsx
+++ b/app/tweet-tagger/src/app/page.tsx
@@ -1,13 +1,17 @@
 "use server";
 
 import { auth } from "auth";
-import { Typography } from "@mui/material";
+import { Alert, Typography } from "@mui/material";
 import TweetEditor from "app/client-component/TweetEditor";
 import { redirect } from "next/navigation";
 import NotAdmin from "app/client-component/NotAdmin";
 import Link from "next/link";
 
-export default async function Home() {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ shareError?: string }>;
+}) {
 
   const session = await auth();
   if (!session?.user) {
@@ -19,6 +23,8 @@ export default async function Home() {
       <NotAdmin />
     );
   }
+
+  const { shareError } = await searchParams;
 
   return (
     <>
@@ -32,6 +38,16 @@ export default async function Home() {
         <Typography variant="body2" color="primary">イベント登録</Typography>
       </Link>
       <Typography>登録画面</Typography>
+      {shareError === "invalid" && (
+        <Alert severity="error">
+          共有された内容からXのポストURLを読み取れませんでした。
+        </Alert>
+      )}
+      {shareError === "failed" && (
+        <Alert severity="error">
+          共有されたポストをドラフト保存できませんでした。もう一度お試しください。
+        </Alert>
+      )}
       <TweetEditor initialId="" />
     </>
   );

--- a/app/tweet-tagger/src/app/share/route.ts
+++ b/app/tweet-tagger/src/app/share/route.ts
@@ -1,0 +1,75 @@
+import { auth } from "auth";
+import { NextResponse } from "next/server";
+import { ensureDraftPost } from "services/postService";
+import { extractPostId } from "utils/postId";
+
+const SEE_OTHER = 303;
+
+function redirectToHome(request: Request, error: "invalid" | "failed") {
+  const url = new URL("/", request.url);
+  url.searchParams.set("shareError", error);
+  return NextResponse.redirect(url, SEE_OTHER);
+}
+
+function redirectToSignIn(request: Request, postId: string) {
+  const callbackUrl = new URL("/share", request.url);
+  callbackUrl.searchParams.set("id", postId);
+
+  const signInUrl = new URL("/api/auth/signin", request.url);
+  signInUrl.searchParams.set("callbackUrl", callbackUrl.toString());
+  return NextResponse.redirect(signInUrl, SEE_OTHER);
+}
+
+async function saveDraftAndRedirect(request: Request, postId: string) {
+  const session = await auth();
+
+  if (!session?.user) {
+    return redirectToSignIn(request, postId);
+  }
+
+  if (session.user.email !== process.env.ADMIN_EMAIL) {
+    return NextResponse.redirect(new URL("/", request.url), SEE_OTHER);
+  }
+
+  try {
+    await ensureDraftPost(postId);
+    return NextResponse.redirect(
+      new URL(`/posts/${postId}/edit?shared=1`, request.url),
+      SEE_OTHER,
+    );
+  } catch (error) {
+    console.error("Error saving shared post as draft:", error);
+    return redirectToHome(request, "failed");
+  }
+}
+
+/**
+ * PWA の共有ターゲットから X の共有内容を受け取る。
+ */
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const postId = extractPostId(
+    formData.get("url")?.toString(),
+    formData.get("text")?.toString(),
+    formData.get("title")?.toString(),
+  );
+
+  if (postId === null) {
+    return redirectToHome(request, "invalid");
+  }
+
+  return saveDraftAndRedirect(request, postId);
+}
+
+/**
+ * 共有時にログインが切れていた場合、ログイン後にドラフト保存を再開する。
+ */
+export async function GET(request: Request) {
+  const postId = extractPostId(new URL(request.url).searchParams.get("id"));
+
+  if (postId === null) {
+    return redirectToHome(request, "invalid");
+  }
+
+  return saveDraftAndRedirect(request, postId);
+}

--- a/app/tweet-tagger/src/services/postService.ts
+++ b/app/tweet-tagger/src/services/postService.ts
@@ -69,6 +69,43 @@ export async function registerPost(post: Post): Promise<void> {
 }
 
 /**
+ * 未登録のポストをギャラリー非公開のドラフトとして保存する。
+ *
+ * 既存ポストは公開状態やタグを含めて一切変更しない。
+ * これにより、公開済みポストを再共有してもドラフトへ戻らない。
+ */
+export async function ensureDraftPost(postId: string): Promise<Post> {
+    await initializeDatabase();
+
+    const postRepository: Repository<Post> = appDataSource.getRepository(Post);
+
+    await postRepository
+        .createQueryBuilder()
+        .insert()
+        .into(Post)
+        .values({
+            id: postId,
+            postedAt: new Date().toISOString(),
+            isDeleted: false,
+            showInGallery: false,
+            shiftSource: null,
+        })
+        .orIgnore()
+        .execute();
+
+    const post = await postRepository.findOne({
+        where: { id: postId },
+    });
+
+    if (post === null) {
+        throw new Error(`ドラフトの保存に失敗しました (postId: ${postId})`);
+    }
+
+    logger.info({ postId, showInGallery: post.showInGallery }, `共有ポストのドラフト保存完了`);
+    return post;
+}
+
+/**
  * 指定のポストIDのポストを取得する
  * @param postId ポストID
  */

--- a/app/tweet-tagger/src/utils/postId.ts
+++ b/app/tweet-tagger/src/utils/postId.ts
@@ -1,0 +1,27 @@
+const X_POST_URL_PATTERN =
+  /https?:\/\/(?:www\.)?(?:x\.com|twitter\.com)\/(?:[^/\s]+\/status|i\/(?:web\/)?status)\/(\d{1,30})/i;
+
+const POST_ID_PATTERN = /^\d{1,30}$/;
+
+/**
+ * X の共有テキスト・URL・ポストIDからポストIDを取り出す。
+ */
+export function extractPostId(
+  ...candidates: Array<string | null | undefined>
+): string | null {
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+
+    const urlMatch = candidate.match(X_POST_URL_PATTERN);
+    if (urlMatch) {
+      return urlMatch[1];
+    }
+
+    const value = candidate.trim();
+    if (POST_ID_PATTERN.test(value)) {
+      return value;
+    }
+  }
+
+  return null;
+}

--- a/e2e/share-draft-flow.spec.ts
+++ b/e2e/share-draft-flow.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test";
+
+const ADMIN_URL = "http://localhost:3001";
+const DRAFT_POST_ID = "2999999999999999901";
+const PUBLISHED_POST_ID = "2999999999999999902";
+
+async function login(page: any) {
+  await page.request.post(`${ADMIN_URL}/api/auth/e2e-login`);
+}
+
+async function deleteTestPost(page: any, postId: string) {
+  await page.request.delete(`${ADMIN_URL}/api/posts/${postId}`);
+}
+
+test.describe("X共有からのドラフト保存", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("共有されたXポストを非公開ドラフトとして保存すること", async ({ page }) => {
+    await deleteTestPost(page, DRAFT_POST_ID);
+
+    try {
+      const response = await page.request.post(`${ADMIN_URL}/share`, {
+        form: {
+          text: `共有テキスト https://x.com/iba_official/status/${DRAFT_POST_ID}`,
+        },
+        maxRedirects: 0,
+      });
+
+      expect(response.status()).toBe(303);
+      expect(response.headers().location).toContain(
+        `/posts/${DRAFT_POST_ID}/edit?shared=1`,
+      );
+
+      const savedPostResponse = await page.request.get(
+        `${ADMIN_URL}/api/posts/${DRAFT_POST_ID}`,
+      );
+      expect(savedPostResponse.ok()).toBeTruthy();
+
+      const savedPost = await savedPostResponse.json();
+      expect(savedPost.showInGallery).toBe(false);
+      expect(savedPost.castTags).toEqual([]);
+
+      await page.goto(`${ADMIN_URL}/posts/${DRAFT_POST_ID}/edit`);
+      await expect(page.getByTestId("draft-status")).toContainText(
+        "ドラフト保存済みです",
+      );
+
+      const publishResponsePromise = page.waitForResponse(
+        (res) =>
+          res.url() === `${ADMIN_URL}/api/posts` &&
+          res.request().method() === "POST",
+      );
+      await page.getByTestId("tweet-register-button").click();
+      const publishResponse = await publishResponsePromise;
+      expect(publishResponse.status()).toBe(201);
+      await expect(page).toHaveURL(`${ADMIN_URL}/posts`);
+
+      const publishedPostResponse = await page.request.get(
+        `${ADMIN_URL}/api/posts/${DRAFT_POST_ID}`,
+      );
+      expect(publishedPostResponse.ok()).toBeTruthy();
+      const publishedPost = await publishedPostResponse.json();
+      expect(publishedPost.showInGallery).toBe(true);
+    } finally {
+      await deleteTestPost(page, DRAFT_POST_ID);
+    }
+  });
+
+  test("公開済みポストを再共有してもドラフトへ戻さないこと", async ({ page }) => {
+    await deleteTestPost(page, PUBLISHED_POST_ID);
+
+    try {
+      const registerResponse = await page.request.post(
+        `${ADMIN_URL}/api/posts`,
+        {
+          data: {
+            post: {
+              id: PUBLISHED_POST_ID,
+              postedAt: new Date().toISOString(),
+              isDeleted: false,
+              showInGallery: true,
+              shiftSource: null,
+              castTags: [],
+              taggedCasts: [],
+              favorites: [],
+            },
+          },
+        },
+      );
+      expect(registerResponse.ok()).toBeTruthy();
+
+      const shareResponse = await page.request.post(`${ADMIN_URL}/share`, {
+        form: {
+          url: `https://x.com/iba_official/status/${PUBLISHED_POST_ID}`,
+        },
+        maxRedirects: 0,
+      });
+      expect(shareResponse.status()).toBe(303);
+
+      const savedPostResponse = await page.request.get(
+        `${ADMIN_URL}/api/posts/${PUBLISHED_POST_ID}`,
+      );
+      expect(savedPostResponse.ok()).toBeTruthy();
+      const savedPost = await savedPostResponse.json();
+      expect(savedPost.showInGallery).toBe(true);
+    } finally {
+      await deleteTestPost(page, PUBLISHED_POST_ID);
+    }
+  });
+
+  test("マニフェストにX共有の受け口が定義されていること", async ({ page }) => {
+    const response = await page.request.get(`${ADMIN_URL}/manifest.webmanifest`);
+    expect(response.ok()).toBeTruthy();
+
+    const manifest = await response.json();
+    expect(manifest.share_target).toEqual({
+      action: "/share",
+      method: "POST",
+      enctype: "application/x-www-form-urlencoded",
+      params: {
+        title: "title",
+        text: "text",
+        url: "url",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## 概要

- PWA の Web Share Target を追加し、X から共有された URL・テキストを管理画面で受け取れるようにしました。
- 共有されたポストを `showInGallery: false` のドラフトとして即時保存し、編集画面へ遷移します。
- 管理画面にドラフト表示と「ギャラリーに公開」操作を追加しました。
- 公開済みポストを再共有してもドラフトへ戻さないようにしています。
- 共有ドラフト、再共有、マニフェストを検証する E2E テストを追加しました。

## 背景

X で見つけたポストを共有した時点で取りこぼさず保存し、キャスト選択などの編集を後から続けられるようにするためです。

## ユーザー・開発者への影響

- インストール済み PWA の共有先から X ポストを管理画面へ送れます。
- 共有直後のポストはギャラリーには表示されず、管理画面から明示的に公開できます。
- 既存の `showInGallery` を利用するため、DB マイグレーションの追加はありません。

## 検証

- Docker Compose で PostgreSQL 17 を起動し、マイグレーション適用済み
- `yarn playwright test e2e/share-draft-flow.spec.ts --reporter=line`：3 passed
- `yarn tsc --noEmit --project app/tweet-tagger/tsconfig.json`：成功
- agent-browser で共有 → ドラフト表示 → 公開 → `showInGallery: true` を確認
- ブラウザページエラーなし

## 補足

ESLint 9 に対する `eslint.config.*` が既存リポジトリにないため、ESLint は設定不足で起動できませんでした。
