### PR TITLE
feat: キャスト登録画面を追加

### DIFF
--- a/app/tweet-tagger/src/app/api/casts/route.ts
+++ b/app/tweet-tagger/src/app/api/casts/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
-import { getAllCasts } from "services/castService";
+import {
+    createCast,
+    DuplicateCastError,
+    getAllCasts,
+} from "services/castService";
 import { auth } from "auth";
+import { CastType } from "@iba-cast-gallery/types";
+import { extractPostId } from "utils/postId";
 
 export async function GET() {
     const session = await auth();
@@ -14,5 +20,73 @@ export async function GET() {
     } catch (error) {
         console.error("Error fetching casts:", error);
         return NextResponse.json({ error: "Failed to fetch casts" }, { status: 500 });
+    }
+}
+
+export async function POST(request: Request) {
+    const session = await auth();
+    if (session?.user?.email !== process.env.ADMIN_EMAIL) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+        return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const values = body as Record<string, unknown>;
+    const name = typeof values.name === "string" ? values.name.trim() : "";
+    const enName = typeof values.enName === "string" ? values.enName.trim() : "";
+    const introduceTweetId = typeof values.introduceTweetId === "string"
+        ? extractPostId(values.introduceTweetId)
+        : null;
+    const fanMark = typeof values.fanMark === "string" ? values.fanMark.trim() : "";
+    const type = values.type;
+    const isActive = values.isActive;
+
+    if (!name || name.length > 30) {
+        return NextResponse.json({ error: "Name must be between 1 and 30 characters" }, { status: 400 });
+    }
+    if (!enName || enName.length > 30) {
+        return NextResponse.json({ error: "English name must be between 1 and 30 characters" }, { status: 400 });
+    }
+    if (!introduceTweetId) {
+        return NextResponse.json({ error: "Invalid introduction post URL or ID" }, { status: 400 });
+    }
+    if (fanMark.length > 20) {
+        return NextResponse.json({ error: "Fan mark must be 20 characters or fewer" }, { status: 400 });
+    }
+    if (type !== CastType.REAL && type !== CastType.IMAGINARY) {
+        return NextResponse.json({ error: "Invalid cast type" }, { status: 400 });
+    }
+    if (typeof isActive !== "boolean") {
+        return NextResponse.json({ error: "isActive must be a boolean" }, { status: 400 });
+    }
+
+    try {
+        const cast = await createCast({
+            name,
+            enName,
+            introduceTweetId,
+            type,
+            isActive,
+            fanMark: fanMark || "-",
+        });
+        return NextResponse.json(cast, { status: 201 });
+    } catch (error) {
+        if (error instanceof DuplicateCastError) {
+            return NextResponse.json(
+                { error: "A cast with the same name, English name, or introduction post already exists" },
+                { status: 409 },
+            );
+        }
+        console.error("Error creating cast:", error);
+        return NextResponse.json({ error: "Failed to create cast" }, { status: 500 });
     }
 }

--- a/app/tweet-tagger/src/app/casts/page.tsx
+++ b/app/tweet-tagger/src/app/casts/page.tsx
@@ -1,0 +1,33 @@
+"use server";
+
+import { auth } from "auth";
+import { redirect } from "next/navigation";
+import { Stack, Typography } from "@mui/material";
+import Link from "next/link";
+import NotAdmin from "app/client-component/NotAdmin";
+import CastEditor from "app/client-component/CastEditor";
+
+export default async function CastsPage() {
+    const session = await auth();
+    if (!session?.user) {
+        redirect("/api/auth/signin");
+    }
+    if (session.user.email !== process.env.ADMIN_EMAIL) {
+        return <NotAdmin />;
+    }
+
+    return (
+        <Stack spacing={2}>
+            <Link href="/">
+                <Typography variant="body2" color="primary">← 登録画面へ</Typography>
+            </Link>
+            <Stack spacing={0.5}>
+                <Typography variant="h6">キャスト登録</Typography>
+                <Typography variant="body2" color="text.secondary">
+                    キャストの基本情報と紹介ポストを登録します。
+                </Typography>
+            </Stack>
+            <CastEditor />
+        </Stack>
+    );
+}

--- a/app/tweet-tagger/src/app/client-component/CastEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/CastEditor.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState } from "react";
+import type { FormEvent } from "react";
+import {
+    Alert,
+    Button,
+    FormControl,
+    FormControlLabel,
+    InputLabel,
+    MenuItem,
+    Select,
+    Snackbar,
+    Stack,
+    Switch,
+    TextField,
+    Typography,
+} from "@mui/material";
+import { CastType } from "@iba-cast-gallery/types";
+import { Tweet } from "../../components/tweet/swr";
+import { extractPostId } from "utils/postId";
+
+const CAST_TYPE_LABELS: Record<CastType, string> = {
+    [CastType.REAL]: "リアルキャスト (RC)",
+    [CastType.IMAGINARY]: "イマジナリーキャスト (IC)",
+};
+
+type SnackbarState = {
+    open: boolean;
+    message: string;
+    severity: "success" | "error";
+};
+
+const CastEditor = () => {
+    const [name, setName] = useState("");
+    const [enName, setEnName] = useState("");
+    const [introduceTweetInput, setIntroduceTweetInput] = useState("");
+    const [type, setType] = useState<CastType>(CastType.REAL);
+    const [fanMark, setFanMark] = useState("");
+    const [isActive, setIsActive] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [snackbar, setSnackbar] = useState<SnackbarState>({
+        open: false,
+        message: "",
+        severity: "success",
+    });
+
+    const introduceTweetId = extractPostId(introduceTweetInput);
+    const isValid = name.trim().length > 0
+        && name.trim().length <= 30
+        && enName.trim().length > 0
+        && enName.trim().length <= 30
+        && fanMark.trim().length <= 20
+        && introduceTweetId !== null;
+
+    const resetForm = () => {
+        setName("");
+        setEnName("");
+        setIntroduceTweetInput("");
+        setType(CastType.REAL);
+        setFanMark("");
+        setIsActive(true);
+    };
+
+    const save = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!isValid || !introduceTweetId) return;
+
+        setSaving(true);
+        try {
+            const response = await fetch("/api/casts", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    name: name.trim(),
+                    enName: enName.trim(),
+                    introduceTweetId,
+                    type,
+                    isActive,
+                    fanMark: fanMark.trim(),
+                }),
+            });
+
+            if (response.status === 409) {
+                setSnackbar({
+                    open: true,
+                    message: "同じ名前・英語名・紹介ポストのキャストがすでに登録されています",
+                    severity: "error",
+                });
+                return;
+            }
+            if (!response.ok) {
+                throw new Error(`Failed to create cast: ${response.status}`);
+            }
+
+            resetForm();
+            setSnackbar({
+                open: true,
+                message: "キャストを登録しました！",
+                severity: "success",
+            });
+        } catch (error) {
+            console.error(error);
+            setSnackbar({
+                open: true,
+                message: "キャストの登録に失敗しました",
+                severity: "error",
+            });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const hasInvalidPostInput = introduceTweetInput.length > 0 && !introduceTweetId;
+
+    return (
+        <Stack
+            component="form"
+            spacing={3}
+            sx={{ width: "100%", maxWidth: 600 }}
+            onSubmit={save}
+        >
+            <TextField
+                required
+                fullWidth
+                label="キャスト名"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                size="small"
+                inputProps={{ maxLength: 30, "data-testid": "cast-name-input" }}
+                helperText={`${name.length}/30`}
+            />
+
+            <TextField
+                required
+                fullWidth
+                label="英語名"
+                value={enName}
+                onChange={(event) => setEnName(event.target.value)}
+                size="small"
+                inputProps={{ maxLength: 30, "data-testid": "cast-en-name-input" }}
+                helperText={`${enName.length}/30`}
+            />
+
+            <FormControl fullWidth size="small">
+                <InputLabel id="cast-type-label">種別</InputLabel>
+                <Select
+                    labelId="cast-type-label"
+                    label="種別"
+                    value={type}
+                    onChange={(event) => setType(Number(event.target.value) as CastType)}
+                    inputProps={{ "data-testid": "cast-type-select" }}
+                >
+                    {[CastType.REAL, CastType.IMAGINARY].map((castType) => (
+                        <MenuItem key={castType} value={castType}>
+                            {CAST_TYPE_LABELS[castType]}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+
+            <TextField
+                required
+                fullWidth
+                label="紹介ポスト URL または ID"
+                value={introduceTweetInput}
+                onChange={(event) => setIntroduceTweetInput(event.target.value)}
+                size="small"
+                placeholder="https://x.com/.../status/..."
+                error={hasInvalidPostInput}
+                helperText={hasInvalidPostInput
+                    ? "XのポストURLまたはポストIDを入力してください"
+                    : "登録前にポストのプレビューを確認できます"}
+                inputProps={{ "data-testid": "cast-introduce-post-input" }}
+            />
+
+            {introduceTweetId && (
+                <Stack spacing={1} data-testid="cast-introduce-post-preview">
+                    <Typography variant="caption" color="text.secondary">
+                        紹介ポストのプレビュー
+                    </Typography>
+                    <Tweet id={introduceTweetId} taggedCasts={[]} />
+                </Stack>
+            )}
+
+            <TextField
+                fullWidth
+                label="ファンマーク（任意）"
+                value={fanMark}
+                onChange={(event) => setFanMark(event.target.value)}
+                size="small"
+                inputProps={{ maxLength: 20, "data-testid": "cast-fan-mark-input" }}
+                helperText={`${fanMark.length}/20（未入力時は「-」で保存）`}
+            />
+
+            <FormControlLabel
+                control={(
+                    <Switch
+                        checked={isActive}
+                        onChange={(event) => setIsActive(event.target.checked)}
+                        data-testid="cast-active-switch"
+                    />
+                )}
+                label="活動中のキャストとして登録"
+            />
+
+            <Button
+                type="submit"
+                variant="contained"
+                disabled={!isValid || saving}
+                data-testid="cast-save-button"
+            >
+                {saving ? "登録中..." : "登録する"}
+            </Button>
+
+            <Snackbar
+                open={snackbar.open}
+                autoHideDuration={5000}
+                onClose={() => setSnackbar((current) => ({ ...current, open: false }))}
+            >
+                <Alert severity={snackbar.severity} variant="filled">
+                    {snackbar.message}
+                </Alert>
+            </Snackbar>
+        </Stack>
+    );
+};
+
+export default CastEditor;

--- a/app/tweet-tagger/src/app/page.tsx
+++ b/app/tweet-tagger/src/app/page.tsx
@@ -28,6 +28,9 @@ export default async function Home({
 
   return (
     <>
+      <Link href="/casts">
+        <Typography variant="body2" color="primary">キャスト登録</Typography>
+      </Link>
       <Link href="/posts">
         <Typography variant="body2" color="primary">登録済みポスト一覧</Typography>
       </Link>

--- a/app/tweet-tagger/src/services/castService.ts
+++ b/app/tweet-tagger/src/services/castService.ts
@@ -3,6 +3,23 @@ import 'reflect-metadata';
 import { initializeDatabase, appDataSource } from "../data-source";
 import { Repository } from "@iba-cast-gallery/dao";
 import { Cast } from "@iba-cast-gallery/dao";
+import { CastType } from "@iba-cast-gallery/types";
+
+export class DuplicateCastError extends Error {
+    constructor() {
+        super("A cast with the same name, English name, or introduction post already exists");
+        this.name = "DuplicateCastError";
+    }
+}
+
+export interface CreateCastInput {
+    name: string;
+    enName: string;
+    introduceTweetId: string;
+    type: CastType;
+    isActive: boolean;
+    fanMark: string;
+}
 
 /**
  * キャスト情報を全件取得する
@@ -18,4 +35,26 @@ export async function getAllCasts(): Promise<Cast[]> {
     });
 
     return casts;
+}
+
+/**
+ * キャスト情報を新規登録する
+ */
+export async function createCast(input: CreateCastInput): Promise<Cast> {
+    await initializeDatabase();
+
+    const castRepository: Repository<Cast> = appDataSource.getRepository(Cast);
+    const duplicate = await castRepository.findOne({
+        where: [
+            { name: input.name },
+            { enName: input.enName },
+            { introduceTweetId: input.introduceTweetId },
+        ],
+    });
+    if (duplicate) {
+        throw new DuplicateCastError();
+    }
+
+    const cast = castRepository.create(input);
+    return castRepository.save(cast);
 }

--- a/e2e/cast-registration.spec.ts
+++ b/e2e/cast-registration.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const ADMIN_URL = "http://localhost:3001";
+const INTRODUCE_POST_ID = "2999999999999999910";
+
+async function login(page: Page) {
+    await page.request.post(`${ADMIN_URL}/api/auth/e2e-login`);
+}
+
+test.describe("キャスト登録画面", () => {
+    test.beforeEach(async ({ page }) => {
+        await login(page);
+    });
+
+    test("入力したキャスト情報を登録APIへ送信できること", async ({ page }) => {
+        let requestBody: Record<string, unknown> | null = null;
+        await page.route("**/api/casts", async (route) => {
+            if (route.request().method() !== "POST") {
+                await route.continue();
+                return;
+            }
+
+            requestBody = route.request().postDataJSON();
+            await route.fulfill({
+                status: 201,
+                contentType: "application/json",
+                body: JSON.stringify({ id: 999, ...requestBody }),
+            });
+        });
+
+        await page.goto(`${ADMIN_URL}/casts`);
+        await expect(page.getByRole("heading", { name: "キャスト登録" })).toBeVisible();
+
+        await page.getByTestId("cast-name-input").fill("E2Eテストキャスト");
+        await page.getByTestId("cast-en-name-input").fill("e2e-test-cast");
+        await page.getByLabel("種別").click();
+        await page.getByRole("option", { name: "イマジナリーキャスト (IC)" }).click();
+        await page.getByTestId("cast-introduce-post-input").fill(
+            `https://x.com/imaginary_base/status/${INTRODUCE_POST_ID}`,
+        );
+        await page.getByTestId("cast-fan-mark-input").fill("🧪");
+
+        await expect(page.getByTestId("cast-save-button")).toBeEnabled();
+        await page.getByTestId("cast-save-button").click();
+
+        await expect(page.getByText("キャストを登録しました！")).toBeVisible();
+        expect(requestBody).toEqual({
+            name: "E2Eテストキャスト",
+            enName: "e2e-test-cast",
+            introduceTweetId: INTRODUCE_POST_ID,
+            type: 2,
+            isActive: true,
+            fanMark: "🧪",
+        });
+        await expect(page.getByTestId("cast-name-input")).toHaveValue("");
+    });
+
+    test("紹介ポストが不正な場合は登録できないこと", async ({ page }) => {
+        await page.goto(`${ADMIN_URL}/casts`);
+
+        await page.getByTestId("cast-name-input").fill("E2Eテストキャスト");
+        await page.getByTestId("cast-en-name-input").fill("e2e-test-cast");
+        await page.getByTestId("cast-introduce-post-input").fill("not-an-x-post");
+
+        await expect(
+            page.getByText("XのポストURLまたはポストIDを入力してください"),
+        ).toBeVisible();
+        await expect(page.getByTestId("cast-save-button")).toBeDisabled();
+    });
+});


### PR DESCRIPTION
## 概要

- 既存の管理画面パス設計に合わせて /casts にキャスト登録画面を追加
- POST /api/casts とDB登録処理、入力検証、重複拒否を追加
- キャスト登録画面のPlaywright E2Eを追加

## 確認内容

- Docker: TypeScript型チェック成功
- Docker: tweet-tagger本番ビルド成功
- Docker: cast-registration.spec.ts 2件成功
- Docker実API: 登録201、重複409、DB保存内容を確認後にテストデータ削除

## 補足

既存のevent-flow.spec.tsは、ローカルテストDBのevent_type_enumにcast_eventが存在しないため500となることを確認しました。今回変更したGET /api/castsは200で応答しており、本PRとは無関係のテストDB不整合です。