### PR TITLE
開発・E2E環境を安定化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
 
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "enableNonRootDocker": "true",
-      "moby": "true"
-    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 
@@ -27,8 +24,8 @@
   },
 
   "forwardPorts": [3000, 3001, 5432],
-  "postCreateCommand": "yarn install && npx playwright install --with-deps && docker-compose up -d && yarn run migrate:dev",
-  "postStartCommand": "docker-compose up -d",
+  "postCreateCommand": "yarn install --immutable && npx playwright install --with-deps && yarn db:start",
+  "postStartCommand": "yarn db:start",
 
   "remoteUser": "node"
 }

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,18 +25,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
 
-      - name: Install Yarn
-        run: npm install -g yarn
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: yarn playwright install --with-deps
 
       - name: Start PostgreSQL database
-        run: sudo docker compose up -d
+        run: sudo docker compose up -d --wait postgres
 
       - name: Run database migrations
         run: yarn migrate
@@ -56,49 +56,22 @@ jobs:
           ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
 
-      - name: Start production server - gallery
-        run: |
-          # ログ出力のバッファリングを0にしつつ起動
-          stdbuf -oL -eL yarn workspace iba-cast-gallery start > iba-cast-gallery-server.log 2>&1 &
-        env:
-          E2E_TESTING: "true"
-          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
-          DB_HOST: localhost
-          DB_PORT: 5432
-          DB_USERNAME: postgres
-          DB_PASSWORD: password
-          DB_DATABASE: ibacastgallery
-          AUTH_URL: http://localhost:3000
-      
-      - name: Start production server - admin
-        run: |
-          # ログ出力のバッファリングを0にしつつ起動
-          stdbuf -oL -eL yarn workspace tweet-tagger start > tweet-tagger-server.log 2>&1 &
-        env:
-          E2E_TESTING: "true"
-          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
-          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
-          DB_HOST: localhost
-          DB_PORT: 5432
-          DB_USERNAME: postgres
-          DB_PASSWORD: password
-          DB_DATABASE: ibacastgallery
-          AUTH_GITHUB_ID: "dummy"
-          AUTH_GITHUB_SECRET: "dummy"
-          AUTH_URL: http://localhost:3001
-          AUTH_TRUST_HOST: true
-
-      - name: Wait for servers to be ready
-        run: |
-          npm install -g wait-on
-          wait-on http://localhost:3000
-
       - name: Run Playwright tests
         run: yarn playwright test
         env:
           E2E_TESTING: "true"
           ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+          AUTH_GITHUB_ID: "dummy"
+          AUTH_GITHUB_SECRET: "dummy"
+          AUTH_TRUST_HOST: "true"
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_USERNAME: postgres
+          DB_PASSWORD: password
+          DB_DATABASE: ibacastgallery
+          DB_SCHEMA: public
+
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
@@ -107,11 +80,3 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
-      
-      - name: Display server logs on failure
-        if: failure()
-        run: |
-          echo "Tweet Tagger Server Logs:"
-          cat tweet-tagger-server.log
-          echo "IBA Cast Gallery Server Logs:"
-          cat iba-cast-gallery-server.log

--- a/app/iba-cast-gallery/package.json
+++ b/app/iba-cast-gallery/package.json
@@ -46,7 +46,7 @@
     "@vitest/coverage-v8": "^4.0.15",
     "eslint-config-next": "^15.5.7",
     "eslint-plugin-storybook": "^10.1.4",
-    "playwright": "^1.57.0",
+    "playwright": "1.57.0",
     "storybook": "^10.1.4",
     "tailwindcss": "^4",
     "vite": "^7.2.6",

--- a/dbreset.sh
+++ b/dbreset.sh
@@ -1,15 +1,8 @@
 # dbコンテナ削除
-docker-compose down -v
+docker compose down -v
 
 # db立ち上げ
-docker-compose up -d
-
-# dbコンテナのhealthcheckが "healthy" になるまで待つ
-echo "Waiting for database to be ready..."
-while [ "`docker inspect -f {{.State.Health.Status}} db`" != "healthy" ]; do
-    sleep 1;
-done
-echo "Database is ready!"
+docker compose up -d --wait postgres
 
 # 準備ができたのを確認してから、マイグレーションを実行
 yarn migrate:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:17-alpine
@@ -17,6 +15,68 @@ services:
       interval: 10s # チェックの間隔
       timeout: 5s   # タイムアウト
       retries: 5    # リトライ回数
+
+  postgres-e2e:
+    profiles: ["test"]
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ibacastgallery
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "5432", "-U", "postgres"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  test-runner:
+    profiles: ["test"]
+    image: mcr.microsoft.com/playwright:v1.57.0-noble
+    init: true
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-1000}"
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    ports:
+      - "${GALLERY_PORT:-3000}:3000"
+      - "${ADMIN_PORT:-3001}:3001"
+    environment:
+      HOME: /tmp/iba-cast-gallery-test-home
+      NEXT_TELEMETRY_DISABLED: "1"
+      E2E_TESTING: "true"
+      E2E_SERIAL: "true"
+      ADMIN_EMAIL: "${ADMIN_EMAIL:-test@example.com}"
+      AUTH_SECRET: "${AUTH_SECRET:-dummy_secret_for_local_development}"
+      AUTH_GITHUB_ID: "dummy"
+      AUTH_GITHUB_SECRET: "dummy"
+      AUTH_TRUST_HOST: "true"
+      DB_HOST: postgres-e2e
+      DB_PORT: "5432"
+      DB_USERNAME: postgres
+      DB_PASSWORD: password
+      DB_MIGRATION_USER_USERNAME: postgres
+      DB_MIGRATION_USER_PASSWORD: password
+      DB_DATABASE: ibacastgallery
+      DB_SCHEMA: public
+    depends_on:
+      postgres-e2e:
+        condition: service_healthy
+    command:
+      - bash
+      - -lc
+      - |
+        mkdir -p "$$HOME"
+        node .yarn/releases/yarn-4.9.0.cjs install --immutable
+        node .yarn/releases/yarn-4.9.0.cjs migrate
+        touch /tmp/test-runner-ready
+        exec sleep infinity
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /tmp/test-runner-ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 90
 
 # ボリューム定義
 volumes:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "migrate:generate": "dotenv -e .env.development -- turbo run migration:generate --filter=@iba-cast-gallery/dao",
     "migrate": "yarn turbo migrate:run --filter=@iba-cast-gallery/db-migrator",
     "migrate:fresh": "dotenv -e .env.development -- turbo run schema:drop --filter=@iba-cast-gallery/db-migrator && yarn migrate:dev",
+    "db:start": "docker compose up -d --wait postgres && yarn migrate:dev",
     "db:reset": "./dbreset.sh",
+    "test:env:up": "docker compose --profile test up -d --wait --wait-timeout 600 --force-recreate postgres-e2e test-runner",
+    "test:env:down": "docker compose --profile test rm -sf test-runner postgres-e2e",
+    "test:e2e:docker": "docker compose --profile test up -d --wait --wait-timeout 600 --force-recreate postgres-e2e test-runner && docker compose --profile test exec -T test-runner node .yarn/releases/yarn-4.9.0.cjs turbo build && docker compose --profile test exec -T -e PLAYWRIGHT_USE_PRODUCTION_SERVER=true test-runner node .yarn/releases/yarn-4.9.0.cjs playwright test",
     "test:e2e:fresh": "yarn migrate:fresh && npx playwright test",
     "test:e2e": "npx playwright test"
   },
@@ -21,7 +25,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@playwright/test": "^1.54.2",
+    "@playwright/test": "1.57.0",
     "@types/node": "^20",
     "dotenv-cli": "^8.0.0",
     "eslint": "^9",

--- a/packages/dao/src/migrations/1785110400000-syncCastSequence.ts
+++ b/packages/dao/src/migrations/1785110400000-syncCastSequence.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * IDを明示して投入した初期キャストデータに採番シーケンスを追従させる。
+ */
+export class SyncCastSequence1785110400000 implements MigrationInterface {
+    private readonly schema = process.env.DB_SCHEMA ?? "public";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            SELECT setval(
+                pg_get_serial_sequence('"${this.schema}"."casts"', 'id'),
+                COALESCE(MAX(id), 1),
+                MAX(id) IS NOT NULL
+            )
+            FROM "${this.schema}"."casts"
+        `);
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        // 既に採番されたIDとの衝突を避けるため、シーケンスは巻き戻さない。
+    }
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,9 +9,6 @@
     "clean": "rimraf dist tsconfig.tsbuildinfo"
   },
   "keywords": [],
-  "dependencies": {
-    "@iba-cast-gallery/dao": "workspaces:*"
-  },
   "devDependencies": {
     "rimraf": "^5.0.7",
     "typescript": "^5.2.2"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,15 +1,36 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'test@example.com';
+const IS_CI = !!process.env.CI;
+const USE_PRODUCTION_SERVER = IS_CI || process.env.PLAYWRIGHT_USE_PRODUCTION_SERVER === 'true';
+const SERVER_COMMAND = USE_PRODUCTION_SERVER ? 'start' : 'dev';
+
+const commonServerEnv = {
+  E2E_TESTING: 'true',
+  ADMIN_EMAIL,
+  AUTH_SECRET: process.env.AUTH_SECRET || 'dummy_secret_for_local_development',
+  AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID || 'dummy',
+  AUTH_GITHUB_SECRET: process.env.AUTH_GITHUB_SECRET || 'dummy',
+  AUTH_TRUST_HOST: 'true',
+  DB_HOST: process.env.DB_HOST || 'localhost',
+  DB_PORT: process.env.DB_PORT || '5432',
+  DB_USERNAME: process.env.DB_USERNAME || 'postgres',
+  DB_PASSWORD: process.env.DB_PASSWORD || 'password',
+  DB_DATABASE: process.env.DB_DATABASE || 'ibacastgallery',
+  DB_SCHEMA: process.env.DB_SCHEMA || 'public',
+};
 
 export default defineConfig({
   testDir: './e2e',
-  fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  fullyParallel: false,
+  forbidOnly: IS_CI,
+  retries: IS_CI ? 2 : 0,
+  workers: IS_CI || process.env.E2E_SERIAL === 'true' ? 1 : undefined,
   reporter: 'html',
   globalSetup: require.resolve('./e2e/global-setup.ts'),
+  expect: {
+    timeout: 30_000,
+  },
   use: {
     trace: process.env.CI ? 'on-first-retry' : 'on',
     permissions: ['clipboard-read', 'clipboard-write'],
@@ -24,41 +45,26 @@ export default defineConfig({
     },
   ],
 
-  // 手動で立ち上げるのでコメントアウト
-  // webServer: [
-  //   {
-  //     command: 'yarn workspace tweet-tagger dev',
-  //     url: 'http://localhost:3001',
-  //     reuseExistingServer: !process.env.CI,
-  //     timeout: 300000, // 5 minutes
-  //     env: {
-  //       E2E_TESTING: "true",
-  //       ADMIN_EMAIL: ADMIN_EMAIL,
-  //       AUTH_SECRET: "dummy_secret_for_local_development",
-  //       DB_HOST: "localhost",
-  //       DB_PORT: "5432",
-  //       DB_USERNAME: "postgres",
-  //       DB_PASSWORD: "password",
-  //       DB_DATABASE: "ibacastgallery",
-  //       AUTH_GITHUB_ID: "dummy",
-  //       AUTH_GITHUB_SECRET: "dummy",
-  //     }
-  //   },
-  //   {
-  //     command: 'yarn workspace iba-cast-gallery dev',
-  //     url: 'http://localhost:3000',
-  //     reuseExistingServer: !process.env.CI,
-  //     timeout: 300000, // 5 minutes
-  //     env: {
-  //       DB_HOST: "localhost",
-  //       DB_PORT: "5432",
-  //       DB_USERNAME: "postgres",
-  //       DB_PASSWORD: "password",
-  //       DB_DATABASE: "ibacastgallery",
-  //       AUTH_GITHUB_ID: "dummy",
-  //       AUTH_GITHUB_SECRET: "dummy",
-  //       AUTH_SECRET: "dummy_secret_for_local_development",
-  //     }
-  //   },
-  // ],
+  webServer: [
+    {
+      command: `node .yarn/releases/yarn-4.9.0.cjs workspace tweet-tagger ${SERVER_COMMAND}`,
+      url: 'http://127.0.0.1:3001/api/auth/session',
+      reuseExistingServer: !IS_CI,
+      timeout: 300000,
+      env: {
+        ...commonServerEnv,
+        AUTH_URL: 'http://localhost:3001',
+      },
+    },
+    {
+      command: `node .yarn/releases/yarn-4.9.0.cjs workspace iba-cast-gallery ${SERVER_COMMAND}`,
+      url: 'http://127.0.0.1:3000/api/casts',
+      reuseExistingServer: !IS_CI,
+      timeout: 300000,
+      env: {
+        ...commonServerEnv,
+        AUTH_URL: 'http://localhost:3000',
+      },
+    },
+  ],
 });

--- a/turbo.json
+++ b/turbo.json
@@ -43,10 +43,10 @@
                 "@iba-cast-gallery/dao#build"
             ]
         },
-        "@iba-cast-gallery/db-migaroter#build": {
+        "@iba-cast-gallery/db-migrator#build": {
             "dependsOn": [
                 "clean",
-                "dao#build"
+                "@iba-cast-gallery/dao#build"
             ],
             "outputs": [
                 "dist/**"

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,7 +962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iba-cast-gallery/dao@workspace:*, @iba-cast-gallery/dao@workspace:packages/dao, @iba-cast-gallery/dao@workspaces:*":
+"@iba-cast-gallery/dao@workspace:*, @iba-cast-gallery/dao@workspace:packages/dao":
   version: 0.0.0-use.local
   resolution: "@iba-cast-gallery/dao@workspace:packages/dao"
   dependencies:
@@ -995,7 +995,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@iba-cast-gallery/types@workspace:packages/types"
   dependencies:
-    "@iba-cast-gallery/dao": "workspaces:*"
     rimraf: "npm:^5.0.7"
     typescript: "npm:^5.2.2"
   languageName: unknown
@@ -1791,7 +1790,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.54.2":
+"@playwright/test@npm:1.57.0":
   version: 1.57.0
   resolution: "@playwright/test@npm:1.57.0"
   dependencies:
@@ -5128,7 +5127,7 @@ __metadata:
   resolution: "iba-cast-gallery-monorepo@workspace:."
   dependencies:
     "@eslint/eslintrc": "npm:^3"
-    "@playwright/test": "npm:^1.54.2"
+    "@playwright/test": "npm:1.57.0"
     "@types/node": "npm:^20"
     dotenv-cli: "npm:^8.0.0"
     eslint: "npm:^9"
@@ -5170,7 +5169,7 @@ __metadata:
     next-auth: "npm:^5.0.0-beta.27"
     nextjs-toploader: "npm:^3.8.16"
     pino: "npm:^9.7.0"
-    playwright: "npm:^1.57.0"
+    playwright: "npm:1.57.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     react-photo-view: "npm:^1.2.7"
@@ -6747,7 +6746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright@npm:1.57.0, playwright@npm:^1.57.0":
+"playwright@npm:1.57.0":
   version: 1.57.0
   resolution: "playwright@npm:1.57.0"
   dependencies:


### PR DESCRIPTION
## 概要

WSL上のソースをそのまま使えるDockerテスト環境を整備し、ローカルとGitHub ActionsのE2E実行経路を安定化しました。

## 変更内容

- Playwright公式イメージとWSLソースのbind mountを使うテストランナーを追加
- E2E専用のtmpfs PostgreSQLとhealthcheckを追加
- Playwrightが管理画面・ギャラリー双方のサーバー起動と停止を管理する構成へ統一
- GitHub ActionsをCorepack、immutable install、Composeのhealth待機へ更新
- 明示IDで投入されたcast初期データにDB sequenceを同期するmigrationを追加
- Turboのdb-migratorタスク名・依存名の誤記とtypes→daoの不要な循環依存を修正
- Playwrightを1.57.0へ固定し、Dockerイメージとブラウザ実体の版ズレを防止
- Dev ContainerをDocker outside of Dockerへ変更

## 背景・原因

従来はDockerへソースをコピーして動作確認しており、WSL側の変更反映と生成物の所有権管理に余分な手順が必要でした。また、E2Eではサーバーの手動起動、固定時間ベースの待機、Playwright/Dockerの版ズレ、seed後のsequence未同期が不安定要因になっていました。

## 影響

`yarn test:e2e:docker` で、空のE2E DB作成、依存確認、migration、Turbo build、本番サーバー起動、E2E実行までを一括で行えます。テスト生成物はWSLユーザーのUID/GIDで作成されます。

## 検証

- `yarn test:e2e:docker`
  - Turbo build: 8/8成功
  - Playwright E2E: 59/59成功（E2E部分 1.9分）
- migration履歴: 19件
- cast最大ID / sequence: 37 / 37
- `docker compose --profile test config --quiet`
- `git diff --check`

## 対象外

ローカルの `docs/X_POST_DIFF_SYNC_DESIGN.md` は別件のため、このPRには含めていません。