### PR TITLE
管理画面の更新ボタンにローディング表示を追加

### DIFF
--- a/app/tweet-tagger/src/app/client-component/CastEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/CastEditor.tsx
@@ -208,6 +208,8 @@ const CastEditor = () => {
                 type="submit"
                 variant="contained"
                 disabled={!isValid || saving}
+                loading={saving}
+                loadingPosition="start"
                 data-testid="cast-save-button"
             >
                 {saving ? "登録中..." : "登録する"}

--- a/app/tweet-tagger/src/app/client-component/EventEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/EventEditor.tsx
@@ -287,12 +287,19 @@ const EventEditor = ({ onSaved, editTarget, onCancelEdit }: {
                     variant="contained"
                     onClick={save}
                     disabled={saving || !dateStart?.isValid() || !dateEnd?.isValid() || !title.trim()}
+                    loading={saving}
+                    loadingPosition="start"
                     data-testid="event-save-button"
                 >
-                    {saving ? "保存中..." : isEditing ? "更新する" : "登録する"}
+                    {saving ? (isEditing ? "更新中..." : "登録中...") : isEditing ? "更新する" : "登録する"}
                 </Button>
                 {isEditing && (
-                    <Button variant="outlined" onClick={onCancelEdit} data-testid="event-cancel-button">
+                    <Button
+                        variant="outlined"
+                        onClick={onCancelEdit}
+                        disabled={saving}
+                        data-testid="event-cancel-button"
+                    >
                         キャンセル
                     </Button>
                 )}

--- a/app/tweet-tagger/src/app/client-component/EventList.tsx
+++ b/app/tweet-tagger/src/app/client-component/EventList.tsx
@@ -28,6 +28,7 @@ const EVENT_TYPE_LABELS: Record<EventType, string> = {
 const EventList = ({ refreshKey, onEdit }: { refreshKey: number; onEdit?: (event: EventDto) => void }) => {
     const [events, setEvents] = useState<EventDto[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [deletingEventId, setDeletingEventId] = useState<number | null>(null);
     const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: "success" | "error" }>({
         open: false, message: "", severity: "success",
     });
@@ -42,7 +43,9 @@ const EventList = ({ refreshKey, onEdit }: { refreshKey: number; onEdit?: (event
     }, [refreshKey]);
 
     const handleDelete = async (id: number, title: string) => {
+        if (deletingEventId !== null) return;
         if (!confirm(`「${title}」を削除しますか？`)) return;
+        setDeletingEventId(id);
         try {
             const res = await fetch(`/api/events/${id}`, { method: "DELETE" });
             if (!res.ok) throw new Error();
@@ -50,6 +53,8 @@ const EventList = ({ refreshKey, onEdit }: { refreshKey: number; onEdit?: (event
             setSnackbar({ open: true, message: "削除しました", severity: "success" });
         } catch {
             setSnackbar({ open: true, message: "削除に失敗しました", severity: "error" });
+        } finally {
+            setDeletingEventId(null);
         }
     };
 
@@ -117,8 +122,24 @@ const EventList = ({ refreshKey, onEdit }: { refreshKey: number; onEdit?: (event
                                 </TableCell>
                                 <TableCell>
                                     <Stack direction="row" spacing={1}>
-                                        <Button size="small" onClick={() => onEdit?.(ev)}>編集</Button>
-                                        <Button size="small" color="error" onClick={() => handleDelete(ev.id, ev.title)}>削除</Button>
+                                        <Button
+                                            size="small"
+                                            onClick={() => onEdit?.(ev)}
+                                            disabled={deletingEventId !== null}
+                                        >
+                                            編集
+                                        </Button>
+                                        <Button
+                                            size="small"
+                                            color="error"
+                                            onClick={() => handleDelete(ev.id, ev.title)}
+                                            disabled={deletingEventId !== null}
+                                            loading={deletingEventId === ev.id}
+                                            loadingPosition="start"
+                                            data-testid={`event-delete-button-${ev.id}`}
+                                        >
+                                            {deletingEventId === ev.id ? "削除中..." : "削除"}
+                                        </Button>
                                     </Stack>
                                 </TableCell>
                             </TableRow>

--- a/app/tweet-tagger/src/app/client-component/ShiftEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/ShiftEditor.tsx
@@ -216,6 +216,8 @@ const ShiftEditor = ({ onSaved }: { onSaved?: () => void }) => {
                 variant="contained"
                 onClick={save}
                 disabled={saving || !date?.isValid()}
+                loading={saving}
+                loadingPosition="start"
                 data-testid="shift-save-button"
             >
                 {saving ? "保存中..." : "保存する"}

--- a/app/tweet-tagger/src/app/client-component/ShiftList.tsx
+++ b/app/tweet-tagger/src/app/client-component/ShiftList.tsx
@@ -227,6 +227,8 @@ const ShiftList = ({ refreshKey }: { refreshKey: number }) => {
                             variant="contained"
                             onClick={saveSource}
                             disabled={savingSource || !sourceTweetId}
+                            loading={savingSource}
+                            loadingPosition="start"
                             data-testid="add-source-save-button"
                         >
                             {savingSource ? "保存中..." : "保存する"}

--- a/app/tweet-tagger/src/app/client-component/TweetDeleter.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetDeleter.tsx
@@ -1,23 +1,36 @@
 "use client";
 
 import { Button, Stack, Dialog, DialogContent, DialogTitle } from "@mui/material";
-import { redirect } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 const TweetDeleter = ({ postId }: { postId: string }) => {
 
+  const router = useRouter();
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const deletePost = async () => {
-    const res = await fetch(`/api/posts/${postId}`, {
-      method: 'DELETE',
-    });
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/posts/${postId}`, {
+        method: 'DELETE',
+      });
 
-    if (res.status === 200) {
-      alert("ポストを削除しました");
-      redirect('/posts');
-    } else {
+      if (res.status === 200) {
+        alert("ポストを削除しました");
+        router.push('/posts');
+        router.refresh();
+        return;
+      }
+
       alert("ポストの削除に失敗しました");
+    } catch (error) {
+      console.error("Error deleting post:", error);
+      alert("ポストの削除に失敗しました");
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -30,8 +43,25 @@ const TweetDeleter = ({ postId }: { postId: string }) => {
         </DialogTitle>
         <DialogContent>
           <Stack spacing={2} direction="row">
-            <Button variant="contained" onClick={() => { setOpenConfirmDialog(false) }} color="primary">キャンセル</Button>
-            <Button variant="contained" onClick={deletePost} color="error">削除</Button>
+            <Button
+              variant="contained"
+              onClick={() => { setOpenConfirmDialog(false) }}
+              color="primary"
+              disabled={deleting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              variant="contained"
+              onClick={deletePost}
+              color="error"
+              disabled={deleting}
+              loading={deleting}
+              loadingPosition="start"
+              data-testid="tweet-delete-confirm-button"
+            >
+              {deleting ? "削除中..." : "削除"}
+            </Button>
           </Stack>
         </DialogContent>
       </Dialog>

--- a/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
@@ -52,9 +52,10 @@ const TweetEditor = ({ initialId }: {
   const [isDeleted, setIsDeleted] = useState<boolean>(false);
   const [castTags, setCastTags] = useState<PostCastTag[]>([]);
   const [showInGallery, setShowInGallery] = useState<boolean | null>(null);
+  const [saving, setSaving] = useState(false);
 
   const registerTweet = async () => {
-    if (tweetDateTime === null) return;
+    if (tweetDateTime === null || saving) return;
 
     const newPost: Post = {
       id: tweetId,
@@ -67,6 +68,7 @@ const TweetEditor = ({ initialId }: {
       favorites: [],
     };
 
+    setSaving(true);
     try {
       const response = await fetch("/api/posts", {
         method: "POST",
@@ -96,6 +98,8 @@ const TweetEditor = ({ initialId }: {
       setTweetDateTime(dayjs());
     } catch (error) {
       console.error("Error registering post:", error);
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -155,8 +159,19 @@ const TweetEditor = ({ initialId }: {
         <DateTimeField format="YYYY/MM/DD HH:mm" label="ツイートの日時" ampm={false} value={tweetDateTime} onChange={(newValue) => setTweetDateTime(newValue)} />
       </LocalizationProvider>
       <FormControlLabel control={<Checkbox checked={isDeleted} onChange={(e, checked) => setIsDeleted(checked)} />} label="削除フラグ" />
-      <Button sx={{ marginTop: 1 }} variant="contained" color="primary" onClick={registerTweet} data-testid='tweet-register-button'>
-        {showInGallery === false ? "ギャラリーに公開" : "登録"}
+      <Button
+        sx={{ marginTop: 1 }}
+        variant="contained"
+        color="primary"
+        onClick={registerTweet}
+        disabled={saving || tweetDateTime === null}
+        loading={saving}
+        loadingPosition="start"
+        data-testid='tweet-register-button'
+      >
+        {saving
+          ? showInGallery === false ? "公開中..." : "登録中..."
+          : showInGallery === false ? "ギャラリーに公開" : "登録"}
       </Button>
     </Stack>
   );

--- a/e2e/mutation-loading.spec.ts
+++ b/e2e/mutation-loading.spec.ts
@@ -1,0 +1,345 @@
+import { expect, test } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+
+const ADMIN_URL = "http://localhost:3001";
+
+function createRequestGate() {
+    let markReached!: () => void;
+    let release!: () => void;
+    const reached = new Promise<void>((resolve) => {
+        markReached = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+        release = resolve;
+    });
+
+    return {
+        reached,
+        release,
+        wait: async () => {
+            markReached();
+            await released;
+        },
+    };
+}
+
+async function login(page: Page) {
+    await page.request.post(`${ADMIN_URL}/api/auth/e2e-login`);
+}
+
+async function expectLoading(button: Locator, label: string) {
+    await expect(button).toBeDisabled();
+    await expect(button).toContainText(label);
+    await expect(button.getByRole("progressbar")).toBeVisible();
+}
+
+test.describe("管理画面のAPI待機表示", () => {
+    test.beforeEach(async ({ page }) => {
+        await login(page);
+    });
+
+    test("キャスト登録中は登録ボタンを無効化してローディング表示する", async ({ page }) => {
+        const gate = createRequestGate();
+        await page.route("**/api/casts", async (route) => {
+            if (route.request().method() !== "POST") {
+                await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+                return;
+            }
+
+            await gate.wait();
+            await route.fulfill({
+                status: 201,
+                contentType: "application/json",
+                body: JSON.stringify({ id: 999 }),
+            });
+        });
+
+        await page.goto(`${ADMIN_URL}/casts`);
+        await page.getByTestId("cast-name-input").fill("ローディングテスト");
+        await page.getByTestId("cast-en-name-input").fill("loading-test");
+        await page.getByTestId("cast-introduce-post-input").fill("2999999999999999910");
+
+        const button = page.getByTestId("cast-save-button");
+        const click = button.click();
+        await gate.reached;
+        await expectLoading(button, "登録中...");
+
+        gate.release();
+        await click;
+        await expect(button.getByRole("progressbar")).not.toBeVisible();
+        await expect(button).toContainText("登録する");
+    });
+
+    test("ポスト登録中は登録ボタンを無効化してローディング表示する", async ({ page }) => {
+        const gate = createRequestGate();
+        await page.route("**/api/casts", async (route) => {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+        });
+        await page.route("**/api/posts", async (route) => {
+            if (route.request().method() !== "POST") {
+                await route.continue();
+                return;
+            }
+
+            await gate.wait();
+            await route.fulfill({ status: 201, contentType: "application/json", body: "{}" });
+        });
+
+        await page.goto(ADMIN_URL);
+        const button = page.getByTestId("tweet-register-button");
+        const click = button.click();
+        await gate.reached;
+        await expectLoading(button, "登録中...");
+
+        gate.release();
+        await click;
+        await expect(button).toBeEnabled();
+        await expect(button).toContainText("登録");
+    });
+
+    test("イベント登録中は登録ボタンを無効化してローディング表示する", async ({ page }) => {
+        const gate = createRequestGate();
+        await page.route("**/api/casts", async (route) => {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+        });
+        await page.route("**/api/events", async (route) => {
+            if (route.request().method() === "GET") {
+                await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+                return;
+            }
+
+            await gate.wait();
+            await route.fulfill({
+                status: 201,
+                contentType: "application/json",
+                body: JSON.stringify({ id: 91 }),
+            });
+        });
+
+        await page.goto(`${ADMIN_URL}/events`);
+        await page.getByTestId("event-title-input").fill("ローディングテストイベント");
+
+        const button = page.getByTestId("event-save-button");
+        const click = button.click();
+        await gate.reached;
+        await expectLoading(button, "登録中...");
+
+        gate.release();
+        await click;
+        await expect(button.getByRole("progressbar")).not.toBeVisible();
+        await expect(button).toContainText("登録する");
+    });
+
+    test("イベント更新中は更新・キャンセルボタンを無効化してローディング表示する", async ({ page }) => {
+        const gate = createRequestGate();
+        const event = {
+            id: 92,
+            eventType: "cast_event",
+            title: "更新前イベント",
+            dateStart: "2099-11-01",
+            dateEnd: "2099-11-01",
+            timeNote: null,
+            notes: null,
+            sourcePostId: null,
+            casts: [],
+        };
+        await page.route("**/api/casts", async (route) => {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+        });
+        await page.route("**/api/events", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify([event]),
+            });
+        });
+        await page.route("**/api/events/92", async (route) => {
+            if (route.request().method() !== "PUT") {
+                await route.continue();
+                return;
+            }
+
+            await gate.wait();
+            await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+        });
+
+        await page.goto(`${ADMIN_URL}/events`);
+        await page.getByTestId("event-list-row-92").getByRole("button", { name: "編集" }).click();
+        await page.getByTestId("event-title-input").fill("更新後イベント");
+
+        const button = page.getByTestId("event-save-button");
+        const cancelButton = page.getByTestId("event-cancel-button");
+        const click = button.click();
+        await gate.reached;
+        await expectLoading(button, "更新中...");
+        await expect(cancelButton).toBeDisabled();
+
+        gate.release();
+        await click;
+    });
+
+    test("シフト保存中は保存ボタンを無効化してローディング表示する", async ({ page }) => {
+        const gate = createRequestGate();
+        await page.route("**/api/casts", async (route) => {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+        });
+        await page.route("**/api/shifts?*", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify({ castIds: [], sourcePostId: null }),
+            });
+        });
+        await page.route("**/api/shifts/list", async (route) => {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+        });
+        await page.route("**/api/shifts", async (route) => {
+            if (route.request().method() !== "POST") {
+                await route.continue();
+                return;
+            }
+
+            await gate.wait();
+            await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+        });
+
+        await page.goto(`${ADMIN_URL}/shifts`);
+        const button = page.getByTestId("shift-save-button");
+        const click = button.click();
+        await gate.reached;
+        await expectLoading(button, "保存中...");
+
+        gate.release();
+        await click;
+        await expect(button).toBeEnabled();
+    });
+
+    test("シフト情報源の保存中は保存ボタンを無効化してローディング表示する", async ({ page }) => {
+        const gate = createRequestGate();
+        await page.route("**/api/casts", async (route) => {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+        });
+        await page.route("**/api/shifts?*", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify({ castIds: [], sourcePostId: null }),
+            });
+        });
+        await page.route("**/api/shifts/list", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify([{
+                    date: "2099-11-01",
+                    dayOfWeek: "日",
+                    shift: "night",
+                    casts: [],
+                    sourcePostId: null,
+                }]),
+            });
+        });
+        await page.route("**/api/shifts/source", async (route) => {
+            await gate.wait();
+            await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+        });
+
+        await page.goto(`${ADMIN_URL}/shifts`);
+        await page.getByTestId("shift-add-source-2099-11-01-night").click();
+        const dialog = page.getByTestId("shift-add-source-dialog");
+        await dialog.getByTestId("add-source-tweet-input").fill("2999999999999999920");
+
+        const button = dialog.getByTestId("add-source-save-button");
+        const click = button.click();
+        await gate.reached;
+        await expectLoading(button, "保存中...");
+
+        gate.release();
+        await click;
+        await expect(dialog).not.toBeVisible();
+    });
+
+    test("イベント削除中は対象ボタンを無効化してローディング表示する", async ({ page }) => {
+        const gate = createRequestGate();
+        const event = {
+            id: 93,
+            eventType: "cast_event",
+            title: "削除対象イベント",
+            dateStart: "2099-11-01",
+            dateEnd: "2099-11-01",
+            timeNote: null,
+            notes: null,
+            sourcePostId: null,
+            casts: [],
+        };
+        await page.route("**/api/casts", async (route) => {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+        });
+        await page.route("**/api/events", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify([event]),
+            });
+        });
+        await page.route("**/api/events/93", async (route) => {
+            await gate.wait();
+            await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+        });
+
+        await page.goto(`${ADMIN_URL}/events`);
+        page.once("dialog", (dialog) => dialog.accept());
+        const button = page.getByTestId("event-delete-button-93");
+        const click = button.click();
+        await gate.reached;
+        await expectLoading(button, "削除中...");
+
+        gate.release();
+        await click;
+        await expect(page.getByTestId("event-list-row-93")).not.toBeVisible();
+    });
+
+    test("ポスト削除中は確定ボタンを無効化してローディング表示する", async ({ page }) => {
+        const gate = createRequestGate();
+        const postId = "2999999999999999930";
+        const post = {
+            id: postId,
+            postedAt: "2099-11-01T00:00:00.000Z",
+            isDeleted: false,
+            showInGallery: true,
+            shiftSource: null,
+            castTags: [],
+            taggedCasts: [],
+            favorites: [],
+        };
+        await page.route("**/api/casts", async (route) => {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+        });
+        await page.route(`**/api/posts/${postId}`, async (route) => {
+            if (route.request().method() === "GET") {
+                await route.fulfill({
+                    status: 200,
+                    contentType: "application/json",
+                    body: JSON.stringify(post),
+                });
+                return;
+            }
+
+            await gate.wait();
+            await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+        });
+
+        await page.goto(`${ADMIN_URL}/posts/${postId}/edit`);
+        await page.getByRole("button", { name: "削除", exact: true }).click();
+
+        const button = page.getByTestId("tweet-delete-confirm-button");
+        const click = button.click();
+        await gate.reached;
+        await expectLoading(button, "削除中...");
+
+        page.once("dialog", (dialog) => dialog.accept());
+        gate.release();
+        await click;
+        await expect(page).toHaveURL(`${ADMIN_URL}/posts`);
+    });
+});


### PR DESCRIPTION
## 概要

管理画面の登録・更新系APIを実行するボタンに、応答待ちのdisabled状態とスピナー、処理中ラベルを追加しました。

## 背景 / 原因

一部の画面は処理中テキストのみでスピナーがなく、ポスト登録・削除などはAPI待機状態自体を持っていませんでした。そのため、応答待ちであることが分かりにくく、ボタンを再操作できる箇所がありました。

## 変更内容

- キャスト登録、ポスト登録・公開、イベント登録・更新、シフト保存、シフト情報源更新へMUIのローディング表示を追加
- API完了まで対象ボタンをdisabledにし、登録中・更新中・保存中・公開中を表示
- イベント削除・ポスト削除にも同じ待機表示と二重操作防止を追加
- イベント更新/削除中は競合する編集・キャンセル操作も無効化
- API応答を意図的に保留し、disabled・スピナー・ラベル・解除を検証するE2Eを8件追加

## 影響

管理画面の各ミューテーション操作で処理中状態が明確になり、API待機中の重複操作を防げます。APIのリクエスト/レスポンス仕様は変更していません。

## 確認内容

- tweet-tagger production build: 成功（既存のTypeORM/ESLint警告のみ）
- Docker E2E（待機表示の追加8件）: 8 passed
- Docker E2E（全スイート）: 67 passed
- `git diff --cached --check`: 成功

## 対象外

- `docs/X_POST_DIFF_SYNC_DESIGN.md` は別件のため、このPRには含めていません。