### PR TITLE
タグ候補をひらがなで検索可能にする

### DIFF
--- a/app/tweet-tagger/src/app/client-component/TagEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/TagEditor.tsx
@@ -3,7 +3,19 @@
 import { Dispatch, SetStateAction, useState } from "react";
 import { Cast, PostCastTag } from "@iba-cast-gallery/dao";
 import { Button, Autocomplete, TextField, Stack } from "@mui/material";
+import { createFilterOptions } from "@mui/material/Autocomplete";
 import TagSorter from "./TagSorter";
+
+const katakanaToHiragana = (value: string) =>
+  value
+    .normalize("NFKC")
+    .replace(/[\u30A1-\u30F6]/g, (character) =>
+      String.fromCharCode(character.charCodeAt(0) - 0x60)
+    );
+
+const filterOptions = createFilterOptions<Cast>({
+  stringify: (cast) => `${cast.name} ${katakanaToHiragana(cast.name)}`,
+});
 
 type TagEditorProps = {
   casts: Cast[];
@@ -50,6 +62,7 @@ const TagEditor = ({ casts, castTags, setCastTags }: TagEditorProps) => {
           multiple
           options={casts.filter(cast => castTags.every(tag => tag.castid !== cast.id))}
           getOptionLabel={(option) => option.name}
+          filterOptions={filterOptions}
           value={selectedCasts}
           onChange={(event, newValue) => setSelectedCasts(newValue)}
           renderInput={(params) => (

--- a/e2e/tweet-flow.spec.ts
+++ b/e2e/tweet-flow.spec.ts
@@ -37,8 +37,10 @@ test.describe('Tweet Tagger and Gallery Flow', () => {
         // 読み込まれる
         await expect(page.getByTestId(`tweet-container-${tweetId}`)).toBeVisible();
 
-        await page.getByTestId('cast-autocomplete').click();
+        const castAutocomplete = page.getByRole('combobox', { name: '写ってるキャストを選択' });
+        await castAutocomplete.fill('めのう');
         const listbox = page.locator('#cast-autocomplete-listbox');
+        await expect(listbox.getByText('メノウ')).toBeVisible();
         await listbox.getByText('メノウ').click();
 
         await page.getByTestId('cast-autocomplete').click();


### PR DESCRIPTION
## 概要

タグ付け時のAutocompleteで、カタカナのキャスト名をひらがな入力でも検索できるようにしました。
入力欄の値は変換せず、候補側の検索文字列にだけひらがな表記を追加しています。

## 変更内容

- キャスト名をNFKC正規化してからカタカナをひらがなへ変換
- MUI `createFilterOptions` の検索対象を「元の名前 + ひらがな表記」に拡張
- `めのう` の入力で `メノウ` を選択できるE2Eを追加
- DBカラムやAPIの変更はなし

## 動作確認

- 変換ケース: メノウ、クォーツ、ヴァーチャル、半角カナ
- Docker上で `turbo build` 成功
- Docker上で `playwright test e2e/tweet-flow.spec.ts` 成功（1 passed）

## 備考

`docs/X_POST_DIFF_SYNC_DESIGN.md` は別件のため、このPRには含めていません。
