### PR TITLE
ポストIDから投稿日時を自動設定する

### DIFF
--- a/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
@@ -10,7 +10,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { Cast, Post, PostCastTag } from "@iba-cast-gallery/dao";
 import { useRouter } from "next/navigation";
 import TagEditor from "./TagEditor";
-import { extractPostId } from "utils/postId";
+import { extractPostId, getPostCreatedAtFromId } from "utils/postId";
 
 
 /**
@@ -109,6 +109,10 @@ const TweetEditor = ({ initialId }: {
 
       if (response.status === 404) {
         setShowInGallery(null);
+        const createdAt = getPostCreatedAtFromId(tweetId);
+        if (createdAt !== null) {
+          setTweetDateTime(dayjs(createdAt));
+        }
         return;
       }
 
@@ -141,8 +145,13 @@ const TweetEditor = ({ initialId }: {
       return;
     }
 
+    if (postId === null) {
+      setShowInGallery(null);
+      return;
+    }
+
     // ツイートが既存のものか確認して既存ならキャスト情報/投稿日時を更新する
-    checkExistTweet(tweetId);
+    checkExistTweet(postId);
   }, [tweetId]);
 
   return (

--- a/app/tweet-tagger/src/services/postService.ts
+++ b/app/tweet-tagger/src/services/postService.ts
@@ -3,6 +3,7 @@ import { initializeDatabase, appDataSource } from "../data-source";
 import { PostCastTag, Repository } from "@iba-cast-gallery/dao";
 import { Post } from "@iba-cast-gallery/dao";
 import logger from "../logger";
+import { getPostCreatedAtFromId } from "utils/postId";
 
 /**
  * ポスト情報を全件取得する
@@ -78,6 +79,8 @@ export async function ensureDraftPost(postId: string): Promise<Post> {
     await initializeDatabase();
 
     const postRepository: Repository<Post> = appDataSource.getRepository(Post);
+    const postedAt = getPostCreatedAtFromId(postId)?.toISOString()
+        ?? new Date().toISOString();
 
     await postRepository
         .createQueryBuilder()
@@ -85,7 +88,7 @@ export async function ensureDraftPost(postId: string): Promise<Post> {
         .into(Post)
         .values({
             id: postId,
-            postedAt: new Date().toISOString(),
+            postedAt,
             isDeleted: false,
             showInGallery: false,
             shiftSource: null,

--- a/app/tweet-tagger/src/utils/postId.ts
+++ b/app/tweet-tagger/src/utils/postId.ts
@@ -3,6 +3,9 @@ const X_POST_URL_PATTERN =
 
 const POST_ID_PATTERN = /^\d{1,30}$/;
 
+const X_SNOWFLAKE_EPOCH_MS = BigInt("1288834974657");
+const X_SNOWFLAKE_TIMESTAMP_SHIFT = BigInt(22);
+
 /**
  * X の共有テキスト・URL・ポストIDからポストIDを取り出す。
  */
@@ -24,4 +27,19 @@ export function extractPostId(
   }
 
   return null;
+}
+
+/**
+ * X のSnowflake IDに含まれるタイムスタンプから投稿日時を取得する。
+ */
+export function getPostCreatedAtFromId(postId: string): Date | null {
+  if (!POST_ID_PATTERN.test(postId)) {
+    return null;
+  }
+
+  const timestamp =
+    (BigInt(postId) >> X_SNOWFLAKE_TIMESTAMP_SHIFT) + X_SNOWFLAKE_EPOCH_MS;
+  const createdAt = new Date(Number(timestamp));
+
+  return Number.isNaN(createdAt.getTime()) ? null : createdAt;
 }

--- a/e2e/share-draft-flow.spec.ts
+++ b/e2e/share-draft-flow.spec.ts
@@ -41,6 +41,7 @@ test.describe("X共有からのドラフト保存", () => {
       const savedPost = await savedPostResponse.json();
       expect(savedPost.showInGallery).toBe(false);
       expect(savedPost.castTags).toEqual([]);
+      expect(savedPost.postedAt).toBe("2033-07-04T11:51:51.961Z");
 
       await page.goto(`${ADMIN_URL}/posts/${DRAFT_POST_ID}/edit`);
       await expect(page.getByTestId("draft-status")).toContainText(
@@ -70,6 +71,7 @@ test.describe("X共有からのドラフト保存", () => {
 
   test("公開済みポストを再共有してもドラフトへ戻さないこと", async ({ page }) => {
     await deleteTestPost(page, PUBLISHED_POST_ID);
+    const existingPostedAt = "2099-11-01T00:00:00.000Z";
 
     try {
       const registerResponse = await page.request.post(
@@ -78,7 +80,7 @@ test.describe("X共有からのドラフト保存", () => {
           data: {
             post: {
               id: PUBLISHED_POST_ID,
-              postedAt: new Date().toISOString(),
+              postedAt: existingPostedAt,
               isDeleted: false,
               showInGallery: true,
               shiftSource: null,
@@ -105,6 +107,7 @@ test.describe("X共有からのドラフト保存", () => {
       expect(savedPostResponse.ok()).toBeTruthy();
       const savedPost = await savedPostResponse.json();
       expect(savedPost.showInGallery).toBe(true);
+      expect(savedPost.postedAt).toBe(existingPostedAt);
     } finally {
       await deleteTestPost(page, PUBLISHED_POST_ID);
     }

--- a/e2e/tweet-flow.spec.ts
+++ b/e2e/tweet-flow.spec.ts
@@ -11,7 +11,7 @@ async function login(page: any) {
 
 test.describe('Tweet Tagger and Gallery Flow', () => {
     // 登録するツイートID
-    const tweetId = `1954740195934474563`;
+    const tweetId = `1346889436626259968`;
     const tweetUrl = `http://x.com/i/status/${tweetId}`;
 
     test.beforeEach(async ({page})=>{
@@ -19,6 +19,7 @@ test.describe('Tweet Tagger and Gallery Flow', () => {
     })
 
     test('管理画面から登録したポストがギャラリーに表示されること', async ({ page }) => {
+        await page.request.delete(`http://localhost:3001/api/posts/${tweetId}`);
 
         // 管理画面を開く
 
@@ -63,19 +64,17 @@ test.describe('Tweet Tagger and Gallery Flow', () => {
         await expect(page.getByTestId('cast-tag-4')).toHaveText('4 シトリン');
 
         // 登録ボタンを押して登録のPOSTリクエストを待機
-        Promise.all([
+        const [, registerRequest] = await Promise.all([
             page.getByTestId('tweet-register-button').click(),
             page.waitForRequest(request => request.url() === 'http://localhost:3001/api/posts' && request.method() === 'POST')
         ]);
+        expect(registerRequest.postDataJSON().post.postedAt).toBe('2021-01-06T18:40:40.344Z');
 
         await expect(page.getByTestId('tweet-id-input')).toBeEmpty();
 
         await page.goto('http://localhost:3001/posts');
 
-        const tweetListItem1 = page.getByTestId('tweet-list-item-1');
-        await expect(tweetListItem1).toBeVisible();
-
-        const tweetContainer= tweetListItem1.getByTestId(`tweet-container-${tweetId}`);
+        const tweetContainer = page.getByTestId(`tweet-container-${tweetId}`);
         await expect(tweetContainer).toBeVisible();
 
         await expect(tweetContainer.getByTestId('cast-tag-1')).toHaveText('メノウ');


### PR DESCRIPTION
## 概要

ポスト登録時の `postedAt` を、XのSnowflake IDに含まれるタイムスタンプから自動設定するようにしました。
X APIへの追加リクエストやDB変更はありません。

## 変更内容

- ポストIDを `BigInt` として扱い、Snowflake epochとtimestamp部分から投稿日時を算出する共通関数を追加
- 新規ポスト入力時、DB未登録であれば算出した日時を日時欄へ自動反映
- X共有から作成する新規ドラフトも、保存時に同じ算出結果を `postedAt` へ設定
- 既存ポストを再共有した場合は、保存済みの公開状態・投稿日時を変更しない
- 通常登録と共有ドラフトのE2Eへ投稿日時の検証を追加

## ユーザーへの影響

ポストIDまたはXのURLを入力・共有すると、投稿日時を手入力しなくても実際の投稿時刻が設定されます。既存ポストの日時欄と手動編集は引き続き保持されます。

## 動作確認

- Snowflake変換の固定ケース2件と不正値を確認
- Docker上で `turbo build` 成功
- 対象E2E: 4件成功
- Docker上の全E2E: 67件成功

## 備考

`docs/X_POST_DIFF_SYNC_DESIGN.md` は別件のため、このPRには含めていません。