### PR TITLE
ポストのタグ付けとシフト登録を統合する

### DIFF
--- a/app/tweet-tagger/src/app/api/post-registrations/[postId]/route.ts
+++ b/app/tweet-tagger/src/app/api/post-registrations/[postId]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { auth } from "auth";
+import { getPostRegistrationDetail } from "services/postRegistrationQueryService";
+
+export async function GET(
+    _request: Request,
+    { params }: { params: Promise<{ postId: string }> },
+) {
+    const session = await auth();
+    if (session?.user?.email !== process.env.ADMIN_EMAIL) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        const detail = await getPostRegistrationDetail(
+            (await params).postId,
+        );
+        if (!detail) {
+            return NextResponse.json(
+                { error: "ポストが存在しません" },
+                { status: 404 },
+            );
+        }
+
+        return NextResponse.json(detail, { status: 200 });
+    } catch (error) {
+        console.error("Error fetching post registration detail:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch post registration detail" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/tweet-tagger/src/app/api/post-registrations/route.ts
+++ b/app/tweet-tagger/src/app/api/post-registrations/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { auth } from "auth";
+import { PostRegistrationRequest } from "@iba-cast-gallery/types";
+import {
+    PostRegistrationValidationError,
+    registerPostWithDestinations,
+} from "services/postRegistrationService";
+
+/**
+ * POST /api/post-registrations
+ * ポストのギャラリー登録とシフト登録をまとめて行う。
+ */
+export async function POST(request: Request) {
+    const session = await auth();
+    if (session?.user?.email !== process.env.ADMIN_EMAIL) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        const registration =
+            (await request.json()) as PostRegistrationRequest;
+        const result = await registerPostWithDestinations(registration);
+        return NextResponse.json(result, { status: 201 });
+    } catch (error) {
+        if (error instanceof PostRegistrationValidationError) {
+            return NextResponse.json(
+                { error: error.message },
+                { status: 400 },
+            );
+        }
+
+        console.error("Error registering post destinations:", error);
+        return NextResponse.json(
+            { error: "Failed to register post destinations" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/tweet-tagger/src/app/client-component/ShiftPageContent.tsx
+++ b/app/tweet-tagger/src/app/client-component/ShiftPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Divider, Typography } from "@mui/material";
-import ShiftEditor from "app/client-component/ShiftEditor";
+import ShiftEditor from "app/client-component/UnifiedShiftEditor";
 import ShiftList from "app/client-component/ShiftList";
 
 const ShiftPageContent = () => {

--- a/app/tweet-tagger/src/app/client-component/UnifiedShiftEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/UnifiedShiftEditor.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+    Alert,
+    Button,
+    Snackbar,
+    Stack,
+    TextField,
+    ToggleButton,
+    ToggleButtonGroup,
+} from "@mui/material";
+import { DateField } from "@mui/x-date-pickers/DateField";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import dayjs, { Dayjs } from "dayjs";
+import { ShiftSlot } from "@iba-cast-gallery/types";
+import CastMultiSelect, {
+    CastOption,
+} from "../../components/CastMultiSelect";
+import { Tweet } from "../../components/tweet/swr";
+import { extractPostId } from "../../utils/postId";
+
+const SHIFT_LABELS: Record<ShiftSlot, string> = {
+    [ShiftSlot.OPEN]: "オープン",
+    [ShiftSlot.EVENING]: "夕方",
+    [ShiftSlot.NIGHT]: "夜",
+};
+
+const UnifiedShiftEditor = ({ onSaved }: { onSaved?: () => void }) => {
+    const [casts, setCasts] = useState<CastOption[]>([]);
+    const [tweetInput, setTweetInput] = useState("");
+    const [tweetId, setTweetId] = useState("");
+    const [date, setDate] = useState<Dayjs>(dayjs());
+    const [slot, setSlot] = useState<ShiftSlot>(ShiftSlot.NIGHT);
+    const [selectedCastIds, setSelectedCastIds] = useState<number[]>([]);
+    const [saving, setSaving] = useState(false);
+    const [snackbar, setSnackbar] = useState<{
+        open: boolean;
+        message: string;
+        severity: "success" | "error";
+    }>({ open: false, message: "", severity: "success" });
+
+    useEffect(() => {
+        fetch("/api/casts")
+            .then((response) => response.json())
+            .then(setCasts)
+            .catch(console.error);
+    }, []);
+
+    useEffect(() => {
+        setTweetId(extractPostId(tweetInput) ?? "");
+    }, [tweetInput]);
+
+    const fetchExisting = useCallback(async () => {
+        if (!date?.isValid()) {
+            return;
+        }
+
+        const dateString = date.format("YYYY-MM-DD");
+        try {
+            const response = await fetch(
+                `/api/shifts?date=${dateString}&shift=${slot}`,
+            );
+            if (!response.ok) {
+                return;
+            }
+            const data: {
+                castIds: number[];
+                sourcePostId: string | null;
+            } = await response.json();
+            setSelectedCastIds(data.castIds);
+            setTweetInput(data.sourcePostId ?? "");
+        } catch (error) {
+            console.error(error);
+        }
+    }, [date, slot]);
+
+    useEffect(() => {
+        void fetchExisting();
+    }, [fetchExisting]);
+
+    const save = async () => {
+        if (!date?.isValid() || saving) {
+            return;
+        }
+
+        setSaving(true);
+        try {
+            const response = await fetch("/api/shifts", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    date: date.format("YYYY-MM-DD"),
+                    shift: slot,
+                    castIds: selectedCastIds,
+                    sourcePostId: tweetId || null,
+                }),
+            });
+            if (!response.ok) {
+                throw new Error();
+            }
+            setSnackbar({
+                open: true,
+                message: "保存しました！",
+                severity: "success",
+            });
+            onSaved?.();
+        } catch {
+            setSnackbar({
+                open: true,
+                message: "保存に失敗しました",
+                severity: "error",
+            });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <Stack spacing={3} sx={{ width: "100%", maxWidth: 720 }}>
+            <TextField
+                fullWidth
+                label="ツイートURL または ID"
+                value={tweetInput}
+                onChange={(event) => setTweetInput(event.target.value)}
+                size="small"
+                placeholder="https://x.com/.../status/..."
+                slotProps={{
+                    htmlInput: {
+                        "data-testid": "shift-tweet-url-input",
+                    },
+                }}
+            />
+            {tweetId && <Tweet id={tweetId} taggedCasts={[]} />}
+
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DateField
+                    label="日付"
+                    format="YYYY/MM/DD"
+                    value={date}
+                    onChange={(value) => value && setDate(value)}
+                    fullWidth
+                    size="small"
+                    slotProps={{
+                        textField: {
+                            inputProps: {
+                                "data-testid": "shift-date-input",
+                            },
+                        },
+                    }}
+                />
+            </LocalizationProvider>
+
+            <ToggleButtonGroup
+                value={slot}
+                exclusive
+                onChange={(_, value) => value && setSlot(value)}
+                fullWidth
+                size="small"
+            >
+                {Object.values(ShiftSlot).map((shiftSlot) => (
+                    <ToggleButton key={shiftSlot} value={shiftSlot}>
+                        {SHIFT_LABELS[shiftSlot]}
+                    </ToggleButton>
+                ))}
+            </ToggleButtonGroup>
+
+            <CastMultiSelect
+                casts={casts.filter(
+                    (cast) =>
+                        cast.isActive !== false ||
+                        selectedCastIds.includes(cast.id),
+                )}
+                value={selectedCastIds}
+                onChange={setSelectedCastIds}
+                label="出勤中のキャストを選択"
+                helperText="名前をひらがな・カタカナで検索して複数選択できます。"
+                testId="standalone-shift-cast-autocomplete"
+            />
+
+            <Button
+                variant="contained"
+                onClick={save}
+                disabled={saving || !date?.isValid()}
+                loading={saving}
+                loadingPosition="start"
+                data-testid="shift-save-button"
+            >
+                {saving ? "保存中..." : "保存する"}
+            </Button>
+
+            <Snackbar
+                open={snackbar.open}
+                autoHideDuration={3000}
+                onClose={() =>
+                    setSnackbar((current) => ({
+                        ...current,
+                        open: false,
+                    }))
+                }
+            >
+                <Alert
+                    severity={snackbar.severity}
+                    onClose={() =>
+                        setSnackbar((current) => ({
+                            ...current,
+                            open: false,
+                        }))
+                    }
+                >
+                    {snackbar.message}
+                </Alert>
+            </Snackbar>
+        </Stack>
+    );
+};
+
+export default UnifiedShiftEditor;

--- a/app/tweet-tagger/src/app/client-component/UnifiedTweetEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/UnifiedTweetEditor.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import {
+    Alert,
+    Button,
+    Checkbox,
+    FormControlLabel,
+    Paper,
+    Stack,
+    TextField,
+    ToggleButton,
+    ToggleButtonGroup,
+    Typography,
+} from "@mui/material";
+import { DateField } from "@mui/x-date-pickers/DateField";
+import { DateTimeField } from "@mui/x-date-pickers/DateTimeField";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import dayjs, { Dayjs } from "dayjs";
+import { PostRegistrationRequest, ShiftSlot } from "@iba-cast-gallery/types";
+import CastMultiSelect, {
+    CastOption,
+} from "../../components/CastMultiSelect";
+import { Tweet } from "../../components/tweet/swr";
+import { extractPostId, getPostCreatedAtFromId } from "../../utils/postId";
+import {
+    inferShiftFromPostedAt,
+    InferredShift,
+} from "../../utils/shift";
+
+const SHIFT_LABELS: Record<ShiftSlot, string> = {
+    [ShiftSlot.OPEN]: "オープン",
+    [ShiftSlot.EVENING]: "夕方",
+    [ShiftSlot.NIGHT]: "夜",
+};
+
+type RegistrationDetailResponse = {
+    post: {
+        postedAt: string;
+        isDeleted: boolean;
+        showInGallery: boolean;
+        shiftSource: string | null;
+        castTags: { castid: number; order: number }[];
+    };
+    shift: {
+        date: string;
+        slot: ShiftSlot;
+        castIds: number[];
+    } | null;
+};
+
+const getInitialShift = (): InferredShift =>
+    inferShiftFromPostedAt(new Date()) ?? {
+        date: dayjs().format("YYYY-MM-DD"),
+        slot: ShiftSlot.NIGHT,
+    };
+
+const uniqueIds = (ids: number[]) => Array.from(new Set(ids));
+
+const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
+    const router = useRouter();
+    const isEditing = initialId !== "";
+    const initialShift = getInitialShift();
+    const [casts, setCasts] = useState<CastOption[]>([]);
+    const [tweetId, setTweetId] = useState(initialId);
+    const [tweetDateTime, setTweetDateTime] = useState<Dayjs | null>(dayjs());
+    const [isDeleted, setIsDeleted] = useState(false);
+    const [taggedCastIds, setTaggedCastIds] = useState<number[]>([]);
+    const [shiftCastIds, setShiftCastIds] = useState<number[]>([]);
+    const [registerGallery, setRegisterGallery] = useState(true);
+    const [registerShift, setRegisterShift] = useState(false);
+    const [shiftDate, setShiftDate] = useState<Dayjs>(
+        dayjs(initialShift.date),
+    );
+    const [shiftSlot, setShiftSlot] = useState<ShiftSlot>(initialShift.slot);
+    const [showInGallery, setShowInGallery] = useState<boolean | null>(null);
+    const [saving, setSaving] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchCasts = async () => {
+            try {
+                const response = await fetch("/api/casts");
+                if (!response.ok) {
+                    throw new Error();
+                }
+                setCasts(await response.json());
+            } catch (error) {
+                console.error("Error fetching casts:", error);
+                setErrorMessage("キャスト一覧を取得できませんでした");
+            }
+        };
+        void fetchCasts();
+    }, []);
+
+    const applyInferredShift = (dateTime: Dayjs) => {
+        if (!dateTime.isValid()) {
+            return;
+        }
+        const inferred = inferShiftFromPostedAt(dateTime.toISOString());
+        if (inferred) {
+            setShiftDate(dayjs(inferred.date));
+            setShiftSlot(inferred.slot);
+        }
+    };
+
+    useEffect(() => {
+        const postId = extractPostId(tweetId);
+        if (postId !== null && postId !== tweetId) {
+            setTweetId(postId);
+            return;
+        }
+        if (postId === null) {
+            setShowInGallery(null);
+            return;
+        }
+
+        const fetchRegistration = async () => {
+            try {
+                const response = await fetch(
+                    `/api/post-registrations/${postId}`,
+                );
+                if (response.status === 404) {
+                    setShowInGallery(null);
+                    const createdAt = getPostCreatedAtFromId(postId);
+                    if (createdAt) {
+                        const dateTime = dayjs(createdAt);
+                        setTweetDateTime(dateTime);
+                        applyInferredShift(dateTime);
+                    }
+                    return;
+                }
+                if (!response.ok) {
+                    throw new Error();
+                }
+
+                const detail: RegistrationDetailResponse =
+                    await response.json();
+                const dateTime = dayjs(detail.post.postedAt);
+                const orderedTagIds = [...detail.post.castTags]
+                    .sort((a, b) => a.order - b.order)
+                    .map((tag) => tag.castid);
+                setTweetDateTime(dateTime);
+                setIsDeleted(detail.post.isDeleted);
+                setTaggedCastIds(orderedTagIds);
+                setShowInGallery(detail.post.showInGallery);
+                setRegisterGallery(
+                    detail.post.showInGallery ||
+                        detail.post.shiftSource === null,
+                );
+                setRegisterShift(
+                    detail.shift !== null ||
+                        detail.post.shiftSource !== null,
+                );
+
+                if (detail.shift) {
+                    setShiftDate(dayjs(detail.shift.date));
+                    setShiftSlot(detail.shift.slot);
+                    setShiftCastIds(
+                        uniqueIds([
+                            ...orderedTagIds,
+                            ...detail.shift.castIds,
+                        ]),
+                    );
+                } else {
+                    applyInferredShift(dateTime);
+                    setShiftCastIds(orderedTagIds);
+                }
+            } catch (error) {
+                console.error("Error fetching post registration:", error);
+                setErrorMessage("ポスト情報を取得できませんでした");
+            }
+        };
+        void fetchRegistration();
+    }, [tweetId]);
+
+    const handleTaggedCastsChange = (castIds: number[]) => {
+        setTaggedCastIds(castIds);
+        if (registerShift) {
+            setShiftCastIds((current) =>
+                uniqueIds([...castIds, ...current]),
+            );
+        }
+    };
+
+    const handleShiftDestinationChange = (checked: boolean) => {
+        setRegisterShift(checked);
+        if (checked) {
+            setShiftCastIds((current) =>
+                uniqueIds([...taggedCastIds, ...current]),
+            );
+        }
+    };
+
+    const save = async () => {
+        if (saving) {
+            return;
+        }
+        const postId = extractPostId(tweetId);
+        if (postId === null || postId !== tweetId) {
+            setErrorMessage("XのポストURLまたはポストIDを入力してください");
+            return;
+        }
+        if (!registerGallery && !registerShift) {
+            setErrorMessage("登録先を1つ以上選択してください");
+            return;
+        }
+        if (!tweetDateTime?.isValid()) {
+            setErrorMessage("投稿日時を入力してください");
+            return;
+        }
+        if (registerShift && shiftCastIds.length === 0) {
+            setErrorMessage("出勤中のキャストを選択してください");
+            return;
+        }
+        if (registerShift && !shiftDate.isValid()) {
+            setErrorMessage("シフト日付を入力してください");
+            return;
+        }
+
+        const request: PostRegistrationRequest = {
+            postId,
+            postedAt: tweetDateTime.toISOString(),
+            isDeleted,
+            destinations: {
+                gallery: registerGallery,
+                shift: registerShift,
+            },
+            taggedCastIds: registerGallery ? taggedCastIds : [],
+            shiftCastIds: registerShift
+                ? uniqueIds([...taggedCastIds, ...shiftCastIds])
+                : [],
+            shift: registerShift
+                ? {
+                    date: shiftDate.format("YYYY-MM-DD"),
+                    slot: shiftSlot,
+                }
+                : undefined,
+        };
+
+        setSaving(true);
+        setErrorMessage(null);
+        try {
+            const response = await fetch("/api/post-registrations", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(request),
+            });
+            if (!response.ok) {
+                const error = await response.json().catch(() => null);
+                throw new Error(error?.error ?? "登録に失敗しました");
+            }
+            if (registerGallery) {
+                setShowInGallery(true);
+            }
+            if (isEditing) {
+                router.push("/posts");
+                router.refresh();
+                return;
+            }
+
+            const nextShift = getInitialShift();
+            setTweetId("");
+            setTweetDateTime(dayjs());
+            setTaggedCastIds([]);
+            setShiftCastIds([]);
+            setRegisterGallery(true);
+            setRegisterShift(false);
+            setShiftDate(dayjs(nextShift.date));
+            setShiftSlot(nextShift.slot);
+            setIsDeleted(false);
+            setShowInGallery(null);
+        } catch (error) {
+            console.error("Error registering post:", error);
+            setErrorMessage(
+                error instanceof Error ? error.message : "登録に失敗しました",
+            );
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const detectedShift = tweetDateTime?.isValid()
+        ? inferShiftFromPostedAt(tweetDateTime.toISOString())
+        : null;
+    const normalizedPostId = extractPostId(tweetId);
+    const saveDisabled =
+        saving ||
+        normalizedPostId === null ||
+        normalizedPostId !== tweetId ||
+        !tweetDateTime?.isValid() ||
+        (!registerGallery && !registerShift) ||
+        (registerShift && shiftCastIds.length === 0);
+    const buttonLabel =
+        registerGallery && registerShift
+            ? "ギャラリーとシフトに登録"
+            : registerShift
+                ? "シフトに登録"
+                : showInGallery === false
+                    ? "ギャラリーに公開"
+                    : "ギャラリーに登録";
+
+    return (
+        <Stack
+            className="w-full"
+            spacing={2}
+            alignItems="stretch"
+            sx={{ maxWidth: 720 }}
+        >
+            {showInGallery === false && (
+                <Alert severity="info" data-testid="draft-status">
+                    ドラフト保存済みです。このポストはギャラリー非公開で、ギャラリー登録を選ぶと公開されます。
+                </Alert>
+            )}
+            {errorMessage && (
+                <Alert
+                    severity="error"
+                    onClose={() => setErrorMessage(null)}
+                    data-testid="post-registration-error"
+                >
+                    {errorMessage}
+                </Alert>
+            )}
+            <TextField
+                fullWidth
+                value={tweetId}
+                onChange={(event) => setTweetId(event.target.value)}
+                label="XのポストURL または ID"
+                size="small"
+                disabled={isEditing}
+                slotProps={{
+                    htmlInput: { "data-testid": "tweet-id-input" },
+                }}
+            />
+            <Tweet id={tweetId} taggedCasts={[]} />
+
+            <Paper variant="outlined" sx={{ p: 2 }}>
+                <Typography variant="subtitle2">登録先</Typography>
+                <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={registerGallery}
+                                onChange={(_, checked) => {
+                                    setRegisterGallery(checked);
+                                    if (checked && registerShift) {
+                                        setShiftCastIds((current) =>
+                                            uniqueIds([
+                                                ...taggedCastIds,
+                                                ...current,
+                                            ]),
+                                        );
+                                    }
+                                }}
+                                data-testid="gallery-destination-checkbox"
+                            />
+                        }
+                        label="ギャラリーに登録"
+                    />
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={registerShift}
+                                onChange={(_, checked) =>
+                                    handleShiftDestinationChange(checked)
+                                }
+                                data-testid="shift-destination-checkbox"
+                            />
+                        }
+                        label="シフトに登録"
+                    />
+                </Stack>
+            </Paper>
+
+            {registerGallery && (
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                    <CastMultiSelect
+                        casts={casts}
+                        value={taggedCastIds}
+                        onChange={handleTaggedCastsChange}
+                        ordered
+                        label="写ってるキャストを選択"
+                        helperText="姿が写っているキャストだけを選びます。並び順はドラッグで変更できます。"
+                        testId="cast-autocomplete"
+                    />
+                </Paper>
+            )}
+
+            {registerShift && (
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                    <Stack spacing={2}>
+                        <Typography variant="subtitle2">
+                            シフト情報
+                        </Typography>
+                        {detectedShift && (
+                            <Alert severity="info">
+                                投稿時刻から「{detectedShift.date}・
+                                {SHIFT_LABELS[detectedShift.slot]}」と判定しました。
+                                必要なら変更できます。
+                            </Alert>
+                        )}
+                        <CastMultiSelect
+                            casts={casts.filter(
+                                (cast) =>
+                                    cast.isActive !== false ||
+                                    shiftCastIds.includes(cast.id),
+                            )}
+                            value={shiftCastIds}
+                            onChange={(castIds) =>
+                                setShiftCastIds(
+                                    uniqueIds([
+                                        ...taggedCastIds,
+                                        ...castIds,
+                                    ]),
+                                )
+                            }
+                            fixedIds={
+                                registerGallery ? taggedCastIds : []
+                            }
+                            label="出勤中のキャストを選択"
+                            helperText="写真タグのキャストは自動で含まれます。キャストボードにだけ載っているキャストを追加してください。"
+                            testId="shift-cast-autocomplete"
+                        />
+                        <LocalizationProvider dateAdapter={AdapterDayjs}>
+                            <DateField
+                                label="シフト日付"
+                                format="YYYY/MM/DD"
+                                value={shiftDate}
+                                onChange={(value) =>
+                                    value && setShiftDate(value)
+                                }
+                                fullWidth
+                                size="small"
+                                slotProps={{
+                                    textField: {
+                                        inputProps: {
+                                            "data-testid":
+                                                "registration-shift-date-input",
+                                        },
+                                    },
+                                }}
+                            />
+                        </LocalizationProvider>
+                        <ToggleButtonGroup
+                            value={shiftSlot}
+                            exclusive
+                            onChange={(_, value) =>
+                                value && setShiftSlot(value)
+                            }
+                            fullWidth
+                            size="small"
+                        >
+                            {Object.values(ShiftSlot).map((slot) => (
+                                <ToggleButton
+                                    key={slot}
+                                    value={slot}
+                                    data-testid={`registration-shift-slot-${slot}`}
+                                >
+                                    {SHIFT_LABELS[slot]}
+                                </ToggleButton>
+                            ))}
+                        </ToggleButtonGroup>
+                    </Stack>
+                </Paper>
+            )}
+
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DateTimeField
+                    format="YYYY/MM/DD HH:mm"
+                    label="ポストの日時"
+                    ampm={false}
+                    value={tweetDateTime}
+                    onChange={(value) => {
+                        setTweetDateTime(value);
+                        if (value) {
+                            applyInferredShift(value);
+                        }
+                    }}
+                />
+            </LocalizationProvider>
+            <FormControlLabel
+                control={
+                    <Checkbox
+                        checked={isDeleted}
+                        onChange={(_, checked) => setIsDeleted(checked)}
+                    />
+                }
+                label="削除フラグ"
+            />
+            <Button
+                variant="contained"
+                color="primary"
+                onClick={save}
+                disabled={saveDisabled}
+                loading={saving}
+                loadingPosition="start"
+                data-testid="tweet-register-button"
+            >
+                {saving ? "登録中..." : buttonLabel}
+            </Button>
+        </Stack>
+    );
+};
+
+export default UnifiedTweetEditor;

--- a/app/tweet-tagger/src/app/page.tsx
+++ b/app/tweet-tagger/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { auth } from "auth";
 import { Alert, Typography } from "@mui/material";
-import TweetEditor from "app/client-component/TweetEditor";
+import TweetEditor from "app/client-component/UnifiedTweetEditor";
 import { redirect } from "next/navigation";
 import NotAdmin from "app/client-component/NotAdmin";
 import Link from "next/link";

--- a/app/tweet-tagger/src/app/posts/[postId]/edit/page.tsx
+++ b/app/tweet-tagger/src/app/posts/[postId]/edit/page.tsx
@@ -5,7 +5,7 @@ import { Typography } from "@mui/material";
 import { redirect } from "next/navigation";
 import NotAdmin from "app/client-component/NotAdmin";
 import Link from "next/link";
-import TweetEditor from "app/client-component/TweetEditor";
+import TweetEditor from "app/client-component/UnifiedTweetEditor";
 import TweetDeleter from "app/client-component/TweetDeleter";
 
 export default async function Page(

--- a/app/tweet-tagger/src/components/CastMultiSelect.tsx
+++ b/app/tweet-tagger/src/components/CastMultiSelect.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import {
+    Autocomplete,
+    Chip,
+    Stack,
+    TextField,
+    Typography,
+    createFilterOptions,
+} from "@mui/material";
+import {
+    DndContext,
+    DragEndEvent,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    SortableContext,
+    useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { CastType } from "@iba-cast-gallery/types";
+
+export type CastOption = {
+    id: number;
+    name: string;
+    type: CastType;
+    isActive?: boolean;
+};
+
+type CastMultiSelectProps = {
+    casts: CastOption[];
+    value: number[];
+    onChange: (castIds: number[]) => void;
+    label: string;
+    helperText?: string;
+    ordered?: boolean;
+    fixedIds?: number[];
+    testId: string;
+};
+
+const katakanaToHiragana = (value: string) =>
+    value
+        .normalize("NFKC")
+        .replace(/[\u30A1-\u30F6]/g, (character) =>
+            String.fromCharCode(character.charCodeAt(0) - 0x60),
+        );
+
+const filterOptions = createFilterOptions<CastOption>({
+    stringify: (cast) => `${cast.name} ${katakanaToHiragana(cast.name)}`,
+});
+
+const uniqueIds = (ids: number[]) => Array.from(new Set(ids));
+
+function SortableCastChip({
+    cast,
+    index,
+    onDelete,
+    testId,
+}: {
+    cast: CastOption;
+    index: number;
+    onDelete: () => void;
+    testId: string;
+}) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+    } = useSortable({ id: cast.id });
+
+    return (
+        <Chip
+            ref={setNodeRef}
+            {...attributes}
+            {...listeners}
+            style={{
+                transform: CSS.Transform.toString(transform),
+                transition,
+                touchAction: "none",
+            }}
+            label={`${index + 1} ${cast.name}`}
+            onDelete={onDelete}
+            data-testid={`${testId}-selected-${index + 1}`}
+        />
+    );
+}
+
+const CastMultiSelect = ({
+    casts,
+    value,
+    onChange,
+    label,
+    helperText,
+    ordered = false,
+    fixedIds = [],
+    testId,
+}: CastMultiSelectProps) => {
+    const selectedCasts = value
+        .map((id) => casts.find((cast) => cast.id === id))
+        .filter((cast): cast is CastOption => cast !== undefined);
+    const fixedIdSet = new Set(fixedIds);
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: { distance: 5 },
+        }),
+    );
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) {
+            return;
+        }
+
+        const oldIndex = value.indexOf(Number(active.id));
+        const newIndex = value.indexOf(Number(over.id));
+        if (oldIndex === -1 || newIndex === -1) {
+            return;
+        }
+
+        const next = [...value];
+        const [moved] = next.splice(oldIndex, 1);
+        next.splice(newIndex, 0, moved);
+        onChange(next);
+    };
+
+    return (
+        <Stack spacing={1}>
+            {ordered && selectedCasts.length > 0 && (
+                <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+                    <SortableContext items={selectedCasts.map((cast) => cast.id)}>
+                        <Stack
+                            direction="row"
+                            useFlexGap
+                            flexWrap="wrap"
+                            gap={1}
+                            data-testid={`${testId}-selected-list`}
+                        >
+                            {selectedCasts.map((cast, index) => (
+                                <SortableCastChip
+                                    key={cast.id}
+                                    cast={cast}
+                                    index={index}
+                                    testId={testId}
+                                    onDelete={() =>
+                                        onChange(value.filter((id) => id !== cast.id))
+                                    }
+                                />
+                            ))}
+                        </Stack>
+                    </SortableContext>
+                </DndContext>
+            )}
+
+            <Autocomplete
+                fullWidth
+                multiple
+                disableCloseOnSelect={!ordered}
+                options={
+                    ordered
+                        ? casts.filter((cast) => !value.includes(cast.id))
+                        : casts
+                }
+                value={ordered ? [] : selectedCasts}
+                isOptionEqualToValue={(option, selected) =>
+                    option.id === selected.id
+                }
+                getOptionLabel={(option) => option.name}
+                groupBy={(option) =>
+                    option.type === CastType.REAL
+                        ? "リアルキャスト (RC)"
+                        : "イマジナリーキャスト (IC)"
+                }
+                getOptionDisabled={(option) =>
+                    option.isActive === false && !value.includes(option.id)
+                }
+                filterOptions={filterOptions}
+                onChange={(_, newValue) => {
+                    const nextIds = newValue.map((cast) => cast.id);
+                    if (ordered) {
+                        onChange(uniqueIds([...value, ...nextIds]));
+                        return;
+                    }
+                    onChange(uniqueIds([...fixedIds, ...nextIds]));
+                }}
+                renderTags={(tagValue, getTagProps) =>
+                    tagValue.map((cast, index) => {
+                        const tagProps = getTagProps({ index });
+                        const isFixed = fixedIdSet.has(cast.id);
+                        return (
+                            <Chip
+                                {...tagProps}
+                                key={cast.id}
+                                label={
+                                    isFixed
+                                        ? `${cast.name}（写真タグ）`
+                                        : cast.name
+                                }
+                                color={isFixed ? "secondary" : "default"}
+                                onDelete={isFixed ? undefined : tagProps.onDelete}
+                            />
+                        );
+                    })
+                }
+                renderInput={(params) => (
+                    <TextField
+                        {...params}
+                        label={label}
+                        data-testid={testId}
+                        slotProps={{
+                            htmlInput: {
+                                ...params.inputProps,
+                                "data-testid": `${testId}-input`,
+                            },
+                        }}
+                    />
+                )}
+                slotProps={{
+                    listbox: {
+                        id: `${testId}-listbox`,
+                    },
+                }}
+            />
+
+            {helperText && (
+                <Typography variant="caption" color="text.secondary">
+                    {helperText}
+                </Typography>
+            )}
+        </Stack>
+    );
+};
+
+export default CastMultiSelect;

--- a/app/tweet-tagger/src/services/postRegistrationQueryService.ts
+++ b/app/tweet-tagger/src/services/postRegistrationQueryService.ts
@@ -1,0 +1,51 @@
+import "server-only";
+import "reflect-metadata";
+import { Post, Repository, Shift } from "@iba-cast-gallery/dao";
+import { ShiftSlot } from "@iba-cast-gallery/types";
+import { appDataSource, initializeDatabase } from "../data-source";
+
+export type PostRegistrationDetail = {
+    post: Post;
+    shift: {
+        date: string;
+        slot: ShiftSlot;
+        castIds: number[];
+    } | null;
+};
+
+export async function getPostRegistrationDetail(
+    postId: string,
+): Promise<PostRegistrationDetail | null> {
+    await initializeDatabase();
+
+    const postRepository: Repository<Post> = appDataSource.getRepository(Post);
+    const post = await postRepository.findOne({ where: { id: postId } });
+    if (!post) {
+        return null;
+    }
+
+    const shiftRepository: Repository<Shift> =
+        appDataSource.getRepository(Shift);
+    const shiftRecords = await shiftRepository.find({
+        where: { sourcePostId: postId },
+        order: { castId: "ASC" },
+    });
+    const firstShift = shiftRecords[0];
+
+    return {
+        post,
+        shift: firstShift
+            ? {
+                date: firstShift.date,
+                slot: firstShift.shift,
+                castIds: shiftRecords
+                    .filter(
+                        (record) =>
+                            record.date === firstShift.date &&
+                            record.shift === firstShift.shift,
+                    )
+                    .map((record) => record.castId),
+            }
+            : null,
+    };
+}

--- a/app/tweet-tagger/src/services/postRegistrationService.ts
+++ b/app/tweet-tagger/src/services/postRegistrationService.ts
@@ -1,0 +1,210 @@
+import "server-only";
+import "reflect-metadata";
+import { Cast, Post, PostCastTag, Repository, Shift } from "@iba-cast-gallery/dao";
+import {
+    PostRegistrationRequest,
+    PostRegistrationResult,
+    ShiftSlot,
+    ShiftSourceStatus,
+} from "@iba-cast-gallery/types";
+import { appDataSource, initializeDatabase } from "../data-source";
+import logger from "../logger";
+import { extractPostId, getPostCreatedAtFromId } from "../utils/postId";
+import { inferShiftFromPostedAt } from "../utils/shift";
+
+export class PostRegistrationValidationError extends Error {}
+
+const uniqueIds = (ids: number[]) => Array.from(new Set(ids));
+
+const isValidDateString = (value: string) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return false;
+    }
+
+    const [year, month, day] = value.split("-").map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return (
+        date.getUTCFullYear() === year &&
+        date.getUTCMonth() === month - 1 &&
+        date.getUTCDate() === day
+    );
+};
+
+function validateRequest(request: PostRegistrationRequest) {
+    if (extractPostId(request.postId) !== request.postId) {
+        throw new PostRegistrationValidationError("ポストIDが不正です");
+    }
+    if (!request.destinations?.gallery && !request.destinations?.shift) {
+        throw new PostRegistrationValidationError("登録先を1つ以上選択してください");
+    }
+    if (
+        !Array.isArray(request.taggedCastIds) ||
+        !Array.isArray(request.shiftCastIds)
+    ) {
+        throw new PostRegistrationValidationError("キャストの指定が不正です");
+    }
+    if (
+        [...request.taggedCastIds, ...request.shiftCastIds].some(
+            (id) => !Number.isInteger(id) || id <= 0,
+        )
+    ) {
+        throw new PostRegistrationValidationError("キャストIDが不正です");
+    }
+    if (request.postedAt && Number.isNaN(new Date(request.postedAt).getTime())) {
+        throw new PostRegistrationValidationError("投稿日時が不正です");
+    }
+    if (request.destinations.shift && request.shiftCastIds.length === 0) {
+        throw new PostRegistrationValidationError(
+            "シフト登録するキャストを選択してください",
+        );
+    }
+    if (
+        request.destinations.gallery &&
+        request.destinations.shift &&
+        request.taggedCastIds.some(
+            (castId) => !request.shiftCastIds.includes(castId),
+        )
+    ) {
+        throw new PostRegistrationValidationError(
+            "写真タグのキャストは出勤キャストにも含めてください",
+        );
+    }
+    if (request.shift?.date && !isValidDateString(request.shift.date)) {
+        throw new PostRegistrationValidationError("シフト日付が不正です");
+    }
+    if (
+        request.shift?.slot &&
+        !Object.values(ShiftSlot).includes(request.shift.slot)
+    ) {
+        throw new PostRegistrationValidationError("シフト枠が不正です");
+    }
+}
+
+/**
+ * ギャラリーのタグ付けとシフト登録を、選択された登録先だけまとめて保存する。
+ */
+export async function registerPostWithDestinations(
+    request: PostRegistrationRequest,
+): Promise<PostRegistrationResult> {
+    validateRequest(request);
+    await initializeDatabase();
+
+    const taggedCastIds = request.destinations.gallery
+        ? uniqueIds(request.taggedCastIds)
+        : [];
+    const shiftCastIds = request.destinations.shift
+        ? uniqueIds(request.shiftCastIds)
+        : [];
+    const usedCastIds = uniqueIds([...taggedCastIds, ...shiftCastIds]);
+
+    return appDataSource.transaction(async (em) => {
+        if (usedCastIds.length > 0) {
+            const castRepository: Repository<Cast> = em.getRepository(Cast);
+            const casts = await castRepository
+                .createQueryBuilder("cast")
+                .select("cast.id")
+                .where("cast.id IN (:...castIds)", { castIds: usedCastIds })
+                .getMany();
+            if (casts.length !== usedCastIds.length) {
+                throw new PostRegistrationValidationError(
+                    "存在しないキャストが含まれています",
+                );
+            }
+        }
+
+        const postRepository: Repository<Post> = em.getRepository(Post);
+        const existing = await postRepository.findOne({
+            where: { id: request.postId },
+        });
+        const postedAt =
+            request.postedAt ??
+            existing?.postedAt ??
+            getPostCreatedAtFromId(request.postId)?.toISOString() ??
+            new Date().toISOString();
+        const inferredShift = inferShiftFromPostedAt(postedAt);
+
+        if (request.destinations.shift && inferredShift === null) {
+            throw new PostRegistrationValidationError(
+                "投稿日時からシフトを判定できません",
+            );
+        }
+
+        const shift = request.destinations.shift
+            ? {
+                date: request.shift?.date ?? inferredShift!.date,
+                slot: request.shift?.slot ?? inferredShift!.slot,
+            }
+            : null;
+
+        const postValues = {
+            postedAt,
+            isDeleted: request.isDeleted ?? existing?.isDeleted ?? false,
+            showInGallery: request.destinations.gallery
+                ? true
+                : existing?.showInGallery ?? false,
+            shiftSource: request.destinations.shift
+                ? existing?.shiftSource === ShiftSourceStatus.DONE
+                    ? ShiftSourceStatus.DONE
+                    : ShiftSourceStatus.PENDING
+                : existing?.shiftSource ?? null,
+        };
+
+        if (existing) {
+            await postRepository.update(request.postId, postValues);
+        } else {
+            await postRepository.insert({
+                id: request.postId,
+                ...postValues,
+            });
+        }
+
+        if (request.destinations.gallery) {
+            const postCastTagRepository: Repository<PostCastTag> =
+                em.getRepository(PostCastTag);
+            await postCastTagRepository.delete({ postId: request.postId });
+
+            if (taggedCastIds.length > 0) {
+                await postCastTagRepository.insert(
+                    taggedCastIds.map((castId, index) => ({
+                        postId: request.postId,
+                        castid: castId,
+                        order: index + 1,
+                    })),
+                );
+            }
+        }
+
+        if (shift) {
+            const shiftRepository: Repository<Shift> = em.getRepository(Shift);
+            await shiftRepository.delete({ sourcePostId: request.postId });
+            await shiftRepository.delete({
+                date: shift.date,
+                shift: shift.slot,
+            });
+            await shiftRepository.insert(
+                shiftCastIds.map((castId) => ({
+                    date: shift.date,
+                    shift: shift.slot,
+                    castId,
+                    sourcePostId: request.postId,
+                })),
+            );
+        }
+
+        logger.info(
+            {
+                postId: request.postId,
+                destinations: request.destinations,
+                taggedCastIds,
+                shiftCastIds,
+                shift,
+            },
+            "ポストのギャラリー・シフト登録完了",
+        );
+
+        return {
+            postId: request.postId,
+            shift,
+        };
+    });
+}

--- a/app/tweet-tagger/src/utils/shift.ts
+++ b/app/tweet-tagger/src/utils/shift.ts
@@ -1,0 +1,61 @@
+import { ShiftSlot } from "@iba-cast-gallery/types";
+
+const OPEN_END_MINUTES = 16 * 60 + 30;
+const EVENING_END_MINUTES = 18 * 60 + 30;
+
+export type InferredShift = {
+    date: string;
+    slot: ShiftSlot;
+};
+
+/**
+ * 投稿日時を日本時間に変換し、投稿日とシフト枠を推定する。
+ */
+export function inferShiftFromPostedAt(
+    postedAt: string | Date,
+): InferredShift | null {
+    const date = postedAt instanceof Date ? postedAt : new Date(postedAt);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone: "Asia/Tokyo",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+    }).formatToParts(date);
+    const values = Object.fromEntries(
+        parts
+            .filter((part) => part.type !== "literal")
+            .map((part) => [part.type, part.value]),
+    );
+
+    const hour = Number(values.hour);
+    const minute = Number(values.minute);
+    if (
+        !values.year ||
+        !values.month ||
+        !values.day ||
+        Number.isNaN(hour) ||
+        Number.isNaN(minute)
+    ) {
+        return null;
+    }
+
+    const minutes = hour * 60 + minute;
+    const slot =
+        minutes < OPEN_END_MINUTES
+            ? ShiftSlot.OPEN
+            : minutes < EVENING_END_MINUTES
+                ? ShiftSlot.EVENING
+                : ShiftSlot.NIGHT;
+
+    return {
+        date: `${values.year}-${values.month}-${values.day}`,
+        slot,
+    };
+}

--- a/e2e/mutation-loading.spec.ts
+++ b/e2e/mutation-loading.spec.ts
@@ -75,7 +75,7 @@ test.describe("管理画面のAPI待機表示", () => {
         await page.route("**/api/casts", async (route) => {
             await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
         });
-        await page.route("**/api/posts", async (route) => {
+        await page.route("**/api/post-registrations", async (route) => {
             if (route.request().method() !== "POST") {
                 await route.continue();
                 return;
@@ -86,6 +86,7 @@ test.describe("管理画面のAPI待機表示", () => {
         });
 
         await page.goto(ADMIN_URL);
+        await page.getByTestId("tweet-id-input").fill("2999999999999999900");
         const button = page.getByTestId("tweet-register-button");
         const click = button.click();
         await gate.reached;
@@ -93,7 +94,7 @@ test.describe("管理画面のAPI待機表示", () => {
 
         gate.release();
         await click;
-        await expect(button).toBeEnabled();
+        await expect(button).toBeDisabled();
         await expect(button).toContainText("登録");
     });
 

--- a/e2e/post-shift-registration-flow.spec.ts
+++ b/e2e/post-shift-registration-flow.spec.ts
@@ -1,0 +1,233 @@
+import { expect, test } from "@playwright/test";
+import { getTestCasts } from "./lib/test-data";
+import { inferShiftFromPostedAt } from "../app/tweet-tagger/src/utils/shift";
+
+const ADMIN_URL = "http://localhost:3001";
+const GALLERY_URL = "http://localhost:3000";
+const COMBINED_POST_ID = "11646878510085046272";
+const SHIFT_ONLY_POST_ID = "11647271096939446272";
+const COMBINED_DATE = "2098-11-01";
+const SHIFT_ONLY_DATE = "2098-11-02";
+
+async function login(page: any) {
+    await page.request.post(`${ADMIN_URL}/api/auth/e2e-login`);
+}
+
+async function clearRegistration(
+    page: any,
+    postId: string,
+    date: string,
+    slot: "open" | "evening" | "night",
+) {
+    await page.request.post(`${ADMIN_URL}/api/shifts`, {
+        data: { date, shift: slot, castIds: [] },
+    });
+    await page.request.delete(`${ADMIN_URL}/api/posts/${postId}`);
+}
+
+async function selectCast(page: any, label: string, castName: string) {
+    const autocomplete = page.getByRole("combobox", { name: label });
+    await autocomplete.fill(castName);
+    await page.getByRole("option", { name: castName }).click();
+}
+
+test.describe("投稿時刻からのシフト自動判定", () => {
+    test("日本時間の境界でシフト枠を切り替える", () => {
+        expect(
+            inferShiftFromPostedAt("2026-07-01T16:29:59+09:00"),
+        ).toEqual({ date: "2026-07-01", slot: "open" });
+        expect(
+            inferShiftFromPostedAt("2026-07-01T16:30:00+09:00"),
+        ).toEqual({ date: "2026-07-01", slot: "evening" });
+        expect(
+            inferShiftFromPostedAt("2026-07-01T18:29:59+09:00"),
+        ).toEqual({ date: "2026-07-01", slot: "evening" });
+        expect(
+            inferShiftFromPostedAt("2026-07-01T18:30:00+09:00"),
+        ).toEqual({ date: "2026-07-01", slot: "night" });
+    });
+});
+
+const casts = getTestCasts();
+const taggedCast = casts[0] ?? null;
+const boardOnlyCast = casts[1] ?? null;
+
+if (!taggedCast || !boardOnlyCast) {
+    test.describe.skip("ポスト・シフト統合登録（キャストデータなし）", () => {
+        test("スキップ", () => {});
+    });
+} else {
+    test.describe("ポスト・シフト統合登録", () => {
+        test.beforeEach(async ({ page }) => {
+            await login(page);
+            await clearRegistration(
+                page,
+                COMBINED_POST_ID,
+                COMBINED_DATE,
+                "evening",
+            );
+            await clearRegistration(
+                page,
+                SHIFT_ONLY_POST_ID,
+                SHIFT_ONLY_DATE,
+                "night",
+            );
+        });
+
+        test.afterEach(async ({ page }) => {
+            await clearRegistration(
+                page,
+                COMBINED_POST_ID,
+                COMBINED_DATE,
+                "evening",
+            );
+            await clearRegistration(
+                page,
+                SHIFT_ONLY_POST_ID,
+                SHIFT_ONLY_DATE,
+                "night",
+            );
+        });
+
+        test("写真タグを出勤キャストへ自動追加し、ボードのみのキャストも一緒に登録できる", async ({
+            page,
+        }) => {
+            await Promise.all([
+                page.goto(ADMIN_URL),
+                page.waitForResponse((response: any) =>
+                    response.url().includes("/api/casts"),
+                ),
+            ]);
+            await page.getByTestId("tweet-id-input").fill(COMBINED_POST_ID);
+            await page.getByTestId("shift-destination-checkbox").check();
+
+            await expect(
+                page.getByTestId("registration-shift-slot-evening"),
+            ).toHaveAttribute("aria-pressed", "true");
+
+            await selectCast(
+                page,
+                "写ってるキャストを選択",
+                taggedCast.name,
+            );
+            const shiftPicker = page.getByTestId(
+                "shift-cast-autocomplete",
+            );
+            await expect(
+                shiftPicker.getByText(`${taggedCast.name}（写真タグ）`),
+            ).toBeVisible();
+
+            await selectCast(
+                page,
+                "出勤中のキャストを選択",
+                boardOnlyCast.name,
+            );
+            await expect(
+                shiftPicker.getByText(boardOnlyCast.name, { exact: true }),
+            ).toBeVisible();
+
+            const responsePromise = page.waitForResponse(
+                (response) =>
+                    response.url() ===
+                        `${ADMIN_URL}/api/post-registrations` &&
+                    response.request().method() === "POST",
+            );
+            await page.getByTestId("tweet-register-button").click();
+            const response = await responsePromise;
+            expect(response.status()).toBe(201);
+
+            const request = response.request().postDataJSON();
+            expect(request.taggedCastIds).toEqual([taggedCast.id]);
+            expect(request.shiftCastIds).toEqual([
+                taggedCast.id,
+                boardOnlyCast.id,
+            ]);
+            expect(request.shift).toEqual({
+                date: COMBINED_DATE,
+                slot: "evening",
+            });
+
+            const postResponse = await page.request.get(
+                `${ADMIN_URL}/api/posts/${COMBINED_POST_ID}`,
+            );
+            expect(postResponse.ok()).toBeTruthy();
+            const post = await postResponse.json();
+            expect(post.showInGallery).toBe(true);
+            expect(post.castTags.map((tag: any) => tag.castid)).toEqual([
+                taggedCast.id,
+            ]);
+
+            const shiftResponse = await page.request.get(
+                `${ADMIN_URL}/api/shifts?date=${COMBINED_DATE}&shift=evening`,
+            );
+            expect(shiftResponse.ok()).toBeTruthy();
+            const shift = await shiftResponse.json();
+            expect(shift.sourcePostId).toBe(COMBINED_POST_ID);
+            expect(shift.castIds.sort()).toEqual(
+                [taggedCast.id, boardOnlyCast.id].sort(),
+            );
+        });
+
+        test("シフトだけ登録したポストはギャラリータグを持たず非公開になる", async ({
+            page,
+        }) => {
+            await Promise.all([
+                page.goto(ADMIN_URL),
+                page.waitForResponse((response: any) =>
+                    response.url().includes("/api/casts"),
+                ),
+            ]);
+            await page
+                .getByTestId("tweet-id-input")
+                .fill(SHIFT_ONLY_POST_ID);
+            await page.getByTestId("gallery-destination-checkbox").uncheck();
+            await page.getByTestId("shift-destination-checkbox").check();
+            await selectCast(
+                page,
+                "出勤中のキャストを選択",
+                taggedCast.name,
+            );
+
+            const responsePromise = page.waitForResponse(
+                (response) =>
+                    response.url() ===
+                        `${ADMIN_URL}/api/post-registrations` &&
+                    response.request().method() === "POST",
+            );
+            await page.getByTestId("tweet-register-button").click();
+            expect((await responsePromise).status()).toBe(201);
+
+            const postResponse = await page.request.get(
+                `${ADMIN_URL}/api/posts/${SHIFT_ONLY_POST_ID}`,
+            );
+            const post = await postResponse.json();
+            expect(post.showInGallery).toBe(false);
+            expect(post.castTags).toEqual([]);
+
+            await page.goto(GALLERY_URL);
+            await expect(
+                page.getByTestId(`tweet-container-${SHIFT_ONLY_POST_ID}`),
+            ).not.toBeVisible();
+        });
+
+        test("写真タグが出勤キャストに含まれない不整合なリクエストを拒否する", async ({
+            page,
+        }) => {
+            const response = await page.request.post(
+                `${ADMIN_URL}/api/post-registrations`,
+                {
+                    data: {
+                        postId: COMBINED_POST_ID,
+                        destinations: { gallery: true, shift: true },
+                        taggedCastIds: [taggedCast.id],
+                        shiftCastIds: [boardOnlyCast.id],
+                    },
+                },
+            );
+            expect(response.status()).toBe(400);
+            expect(await response.json()).toEqual({
+                error: "写真タグのキャストは出勤キャストにも含めてください",
+            });
+        });
+    });
+}

--- a/e2e/share-draft-flow.spec.ts
+++ b/e2e/share-draft-flow.spec.ts
@@ -50,7 +50,7 @@ test.describe("X共有からのドラフト保存", () => {
 
       const publishResponsePromise = page.waitForResponse(
         (res) =>
-          res.url() === `${ADMIN_URL}/api/posts` &&
+          res.url() === `${ADMIN_URL}/api/post-registrations` &&
           res.request().method() === "POST",
       );
       await page.getByTestId("tweet-register-button").click();

--- a/e2e/shift-flow.spec.ts
+++ b/e2e/shift-flow.spec.ts
@@ -28,6 +28,14 @@ async function setShiftDate(page: any, date: string) {
     await dateLoadedPromise;
 }
 
+async function selectShiftCast(page: any, castName: string) {
+    const autocomplete = page.getByRole('combobox', {
+        name: '出勤中のキャストを選択',
+    });
+    await autocomplete.fill(castName);
+    await page.getByRole('option', { name: castName }).click();
+}
+
 const casts = getTestCasts();
 const testCast = casts[0] ?? null;
 
@@ -56,12 +64,8 @@ if (!testCast) {
             // 固定テスト日付を DateField に入力
             await setShiftDate(page, TEST_DATE);
 
-            // キャストの Chip が表示されていることを確認
-            const castChip = page.getByRole('button', { name: testCast.name }).first();
-            await expect(castChip).toBeVisible();
-
-            // キャストを選択
-            await castChip.click();
+            // 共通のAutocompleteからキャストを選択
+            await selectShiftCast(page, testCast.name);
 
             // 保存ボタンをクリックして POST /api/shifts のレスポンスを待機
             await Promise.all([
@@ -105,8 +109,7 @@ if (!testCast) {
             await expect(page.getByTestId(`tweet-container-${tweetId}`)).toBeVisible({ timeout: 15000 });
 
             // キャストを選択
-            const castChip = page.getByRole('button', { name: testCast.name }).first();
-            await castChip.click();
+            await selectShiftCast(page, testCast.name);
 
             // 保存
             await Promise.all([
@@ -160,9 +163,7 @@ if (!testCast) {
             await setShiftDate(page, TEST_DATE);
 
             // ソースなしでシフトを保存（ツイートURLを入力しない）
-            const castChip = page.getByRole('button', { name: testCast.name }).first();
-            await expect(castChip).toBeVisible();
-            await castChip.click();
+            await selectShiftCast(page, testCast.name);
             await Promise.all([
                 page.getByTestId('shift-save-button').click(),
                 page.waitForResponse((resp: any) =>

--- a/e2e/tweet-flow.spec.ts
+++ b/e2e/tweet-flow.spec.ts
@@ -53,22 +53,22 @@ test.describe('Tweet Tagger and Gallery Flow', () => {
         await page.getByTestId('cast-autocomplete').click();
         await listbox.getByText('シトリン').click();
 
-        await page.getByTestId('add-tag-button').click();
-
-        const tags = await page.locator('[data-testid^="cast-tag-"]');
+        const tags = page.locator(
+            '[data-testid^="cast-autocomplete-selected-"]:not([data-testid="cast-autocomplete-selected-list"])'
+        );
         await expect(tags).toHaveCount(4);
 
-        await expect(page.getByTestId('cast-tag-1')).toHaveText('1 メノウ');
-        await expect(page.getByTestId('cast-tag-2')).toHaveText('2 リシア');
-        await expect(page.getByTestId('cast-tag-3')).toHaveText('3 ベリル');
-        await expect(page.getByTestId('cast-tag-4')).toHaveText('4 シトリン');
+        await expect(page.getByTestId('cast-autocomplete-selected-1')).toHaveText('1 メノウ');
+        await expect(page.getByTestId('cast-autocomplete-selected-2')).toHaveText('2 リシア');
+        await expect(page.getByTestId('cast-autocomplete-selected-3')).toHaveText('3 ベリル');
+        await expect(page.getByTestId('cast-autocomplete-selected-4')).toHaveText('4 シトリン');
 
         // 登録ボタンを押して登録のPOSTリクエストを待機
         const [, registerRequest] = await Promise.all([
             page.getByTestId('tweet-register-button').click(),
-            page.waitForRequest(request => request.url() === 'http://localhost:3001/api/posts' && request.method() === 'POST')
+            page.waitForRequest(request => request.url() === 'http://localhost:3001/api/post-registrations' && request.method() === 'POST')
         ]);
-        expect(registerRequest.postDataJSON().post.postedAt).toBe('2021-01-06T18:40:40.344Z');
+        expect(registerRequest.postDataJSON().postedAt).toBe('2021-01-06T18:40:40.344Z');
 
         await expect(page.getByTestId('tweet-id-input')).toBeEmpty();
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,7 @@
 export { CastType } from "./cast";
 export type { CastDto } from "./cast";
 export type { PostDto, PostWithCastsDto } from "./post";
+export type { PostRegistrationRequest, PostRegistrationResult, ShiftRegistrationInput } from "./postRegistration";
 export { ShiftSlot, ShiftSourceStatus } from "./shift";
 export type { ShiftDto, ShiftGroup } from "./shift";
 export { EventType } from "./event";

--- a/packages/types/src/postRegistration.ts
+++ b/packages/types/src/postRegistration.ts
@@ -1,0 +1,27 @@
+import { ShiftSlot } from "./shift";
+
+export interface ShiftRegistrationInput {
+    date?: string;
+    slot?: ShiftSlot;
+}
+
+export interface PostRegistrationRequest {
+    postId: string;
+    postedAt?: string;
+    isDeleted?: boolean;
+    destinations: {
+        gallery: boolean;
+        shift: boolean;
+    };
+    taggedCastIds: number[];
+    shiftCastIds: number[];
+    shift?: ShiftRegistrationInput;
+}
+
+export interface PostRegistrationResult {
+    postId: string;
+    shift: {
+        date: string;
+        slot: ShiftSlot;
+    } | null;
+}


### PR DESCRIPTION
## 概要

- ポスト登録時に、ギャラリー登録とシフト登録を片方だけ／同時のどちらでも選べるようにしました
- 写真に写っているキャストはシフト側へ自動で含め、キャストボードにだけ載っているキャストを追加できるようにしました
- 投稿時刻を日本時間で判定し、オープン・夕方・夜を自動選択します（手動変更も可能です）
- ポスト登録画面とシフト登録画面で、ひらがな検索対応の共通キャスト選択UIを使うようにしました

## 主な変更

- ギャラリータグとシフトを1トランザクションで保存する統合APIを追加
- 写真タグが出勤キャストの部分集合になるよう、UIとAPIの両方で整合性を保証
- 既存ポスト編集時にギャラリー・シフト情報を復元
- 統合登録フローと既存画面のE2Eテストを更新・追加

## 動作確認

- Docker環境でモノレポ全体のビルド成功
- Playwright E2E: 71件すべて成功
- ブラウザで表示、選択、写真タグからシフトへの自動追加、コンソールエラーなしを確認

## 補足

- UIの使い勝手をVercel Previewで確認するため、Draft PRとして作成します
- `docs/X_POST_DIFF_SYNC_DESIGN.md` は別件のため、このPRには含めていません
