### PR TITLE
fix: Vercel Previewからの本番DB更新を防止

### DIFF
--- a/.github/workflows/preview-db-cleanup.yml
+++ b/.github/workflows/preview-db-cleanup.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+
 jobs:
   cleanup-preview-schema:
     runs-on: ubuntu-latest
@@ -26,6 +29,13 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
+
+      - name: Delete Vercel Preview deployments
+        run: node scripts/delete-preview-deployments.js
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_IDS: ${{ vars.VERCEL_GALLERY_PROJECT_ID }},${{ vars.VERCEL_ADMIN_PROJECT_ID }}
 
       - name: Delete preview schema
         run: node scripts/delete-preview-schema.js

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -101,6 +101,7 @@ jobs:
               --token="$VERCEL_TOKEN" \
               --env "DB_SCHEMA=$DB_SCHEMA" \
               --meta "githubDeployment=1" \
+              --meta "githubPullRequestId=${{ github.event.pull_request.number }}" \
               --meta "githubCommitOrg=${GITHUB_REPOSITORY_OWNER}" \
               --meta "githubCommitRepo=${GITHUB_REPOSITORY#*/}" \
               --meta "githubCommitRef=$HEAD_BRANCH" \
@@ -156,6 +157,7 @@ jobs:
               --token="$VERCEL_TOKEN" \
               --env "DB_SCHEMA=$DB_SCHEMA" \
               --meta "githubDeployment=1" \
+              --meta "githubPullRequestId=${{ github.event.pull_request.number }}" \
               --meta "githubCommitOrg=${GITHUB_REPOSITORY_OWNER}" \
               --meta "githubCommitRepo=${GITHUB_REPOSITORY#*/}" \
               --meta "githubCommitRef=$HEAD_BRANCH" \

--- a/app/iba-cast-gallery/src/data-source.ts
+++ b/app/iba-cast-gallery/src/data-source.ts
@@ -1,8 +1,9 @@
 import { DataSource } from 'typeorm';
-import { commonDataSourceOptions } from '@iba-cast-gallery/dao';
+import { commonDataSourceOptions, resolveDatabaseSchema } from '@iba-cast-gallery/dao';
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions.js';
 
 const NODE_ENV = process.env.NODE_ENV as 'development' | 'production' | 'preview' | undefined;
+const databaseSchema = resolveDatabaseSchema(process.env);
 
 export const appDataSource = new DataSource({
   ...commonDataSourceOptions,
@@ -13,10 +14,10 @@ export const appDataSource = new DataSource({
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
-  schema: process.env.DB_SCHEMA,
+  schema: databaseSchema,
   logging: NODE_ENV === 'development' || NODE_ENV === 'preview' ? ['query', 'error', 'migration'] : false,
   extra: {
-    options: `-c search_path=${process.env.DB_SCHEMA || 'public'},public`
+    options: `-c search_path=${databaseSchema},public`
   },
 } as PostgresConnectionOptions);
 

--- a/app/tweet-tagger/src/data-source.ts
+++ b/app/tweet-tagger/src/data-source.ts
@@ -1,8 +1,9 @@
 import { DataSource } from 'typeorm';
-import { commonDataSourceOptions } from '@iba-cast-gallery/dao';
+import { commonDataSourceOptions, resolveDatabaseSchema } from '@iba-cast-gallery/dao';
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions.js';
 
 const NODE_ENV = process.env.NODE_ENV as 'development' | 'production' | 'preview' | undefined;
+const databaseSchema = resolveDatabaseSchema(process.env);
 
 export const appDataSource = new DataSource({
     ...commonDataSourceOptions,
@@ -13,10 +14,10 @@ export const appDataSource = new DataSource({
     username: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_DATABASE,
-    schema: process.env.DB_SCHEMA,
+    schema: databaseSchema,
     logging: NODE_ENV === 'development' || NODE_ENV === 'preview' ? ['query', 'error', 'migration'] : false,
     extra: {
-        options: `-c search_path=${process.env.DB_SCHEMA || 'public'},public`
+        options: `-c search_path=${databaseSchema},public`
     },
 } as PostgresConnectionOptions);
 

--- a/docs/PREVIEW_DB_SETUP.md
+++ b/docs/PREVIEW_DB_SETUP.md
@@ -4,15 +4,15 @@
 
 ## 概要
 
-PRが作成されると、自動的に専用のデータベーススキーマが作成され、Preview環境ではそのスキーマを使用します。PRがクローズされると、スキーマは自動的に削除されます。
+PRが作成されると、自動的に専用のデータベーススキーマが作成され、Preview環境ではそのスキーマを使用します。PRがクローズされると、対応するVercel Previewデプロイを先に削除してから、スキーマを削除します。Vercel APIの削除に失敗した場合はスキーマを残し、削除済みのPreviewが本番スキーマへフォールバックする事態を防ぎます。
 
 ## アーキテクチャ
 
 - **スキーマ命名規則**: `preview_pr_{PR番号}`
   - 例: PR #123 の場合、`preview_pr_123` というスキーマが作成されます
 - **自動化**:
-  - PR作成/更新時: `.github/workflows/preview-db-setup.yml` が実行され、スキーマを作成しマイグレーションを実行
-  - PRクローズ時: `.github/workflows/preview-db-cleanup.yml` が実行され、スキーマを削除
+  - PR作成/更新時: `.github/workflows/preview-deployment.yml` が実行され、スキーマを作成しマイグレーションを実行
+  - PRクローズ時: `.github/workflows/preview-db-cleanup.yml` が実行され、Vercel Previewデプロイを削除してからスキーマを削除
 
 ## GitHub Secretsの設定
 
@@ -139,7 +139,7 @@ DB_SCHEMA=preview_pr_$REVIEW_ID
 3. PRにコメントが追加され、スキーマ名が表示されることを確認します
 4. Vercel Preview Deploymentがデプロイされ、正常に動作することを確認します
 5. PRをクローズします
-6. GitHub Actionsで `Preview DB Cleanup` ワークフローが実行され、スキーマが削除されることを確認します
+6. GitHub Actionsで `Preview DB Cleanup` ワークフローが実行され、Vercel Previewデプロイとスキーマが削除されることを確認します
 
 **デバッグ方法**: Vercel Deployment Logs で以下の環境変数を確認できます:
 ```
@@ -194,6 +194,24 @@ node scripts/delete-preview-schema.js
 ```
 
 ## メンテナンス
+
+### 古いVercel Previewデプロイの整理
+
+`scripts/cleanup-stale-preview-deployments.js` は、過去のPreviewデプロイを安全に整理するための一回限りの運用スクリプトです。Productionおよびカスタム環境のデプロイは対象にせず、最初は必ず削除候補を表示するだけです。
+
+```bash
+export VERCEL_TOKEN=your-vercel-token
+export VERCEL_ORG_ID=your-vercel-team-id
+export VERCEL_PROJECT_IDS=gallery-project-id,admin-project-id
+
+# 削除せず、2026-07-01より前のPreview候補を確認する
+node scripts/cleanup-stale-preview-deployments.js --before 2026-07-01
+
+# 確認した候補を削除する。残したいブランチは --keep-branch で除外する
+node scripts/cleanup-stale-preview-deployments.js --before 2026-07-01 --keep-branch active-pr-branch --execute
+```
+
+`--execute` を使う場合は `--before` が必須です。`--before` はUTCとして扱われます。Dry Runの出力を確認してから同じ条件で実行してください。
 
 定期的に不要なスキーマが残っていないか確認することをお勧めします:
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:env:down": "docker compose --profile test rm -sf test-runner postgres-e2e",
     "test:e2e:docker": "docker compose --profile test up -d --wait --wait-timeout 600 --force-recreate postgres-e2e test-runner && docker compose --profile test exec -T test-runner node .yarn/releases/yarn-4.9.0.cjs turbo build && docker compose --profile test exec -T -e PLAYWRIGHT_USE_PRODUCTION_SERVER=true test-runner node .yarn/releases/yarn-4.9.0.cjs playwright test",
     "test:e2e:fresh": "yarn migrate:fresh && npx playwright test",
-    "test:e2e": "npx playwright test"
+    "test:e2e": "npx playwright test",
+    "test:unit": "yarn workspace @iba-cast-gallery/dao build && node --test packages/dao/dist/database-schema.test.js scripts/delete-preview-deployments.test.js scripts/cleanup-stale-preview-deployments.test.js"
   },
   "dependencies": {
     "pg": "^8.14.1"

--- a/packages/dao/src/database-schema.test.ts
+++ b/packages/dao/src/database-schema.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveDatabaseSchema } from './database-schema';
+
+test('Vercel PreviewではPRごとのスキーマを返す', () => {
+  assert.equal(
+    resolveDatabaseSchema({
+      VERCEL_ENV: 'preview',
+      DB_SCHEMA: 'preview_pr_142',
+    }),
+    'preview_pr_142',
+  );
+});
+
+test('Vercel Previewでスキーマが未指定なら起動を拒否する', () => {
+  assert.throws(
+    () => resolveDatabaseSchema({ VERCEL_ENV: 'preview' }),
+    /preview_pr_<PR番号>/,
+  );
+
+  assert.throws(
+    () => resolveDatabaseSchema({ VERCEL_ENV: 'preview', DB_SCHEMA: 'public' }),
+    /preview_pr_<PR番号>/,
+  );
+});
+
+test('本番環境はpublicスキーマを既定値にする', () => {
+  assert.equal(resolveDatabaseSchema({ VERCEL_ENV: 'production' }), 'public');
+});

--- a/packages/dao/src/database-schema.ts
+++ b/packages/dao/src/database-schema.ts
@@ -1,0 +1,18 @@
+export type DatabaseEnvironment = Record<string, string | undefined>;
+
+const previewSchemaPattern = /^preview_pr_\d+$/;
+
+/**
+ * Vercel Preview が本番スキーマへ接続しないよう、実行時のスキーマ名を検証する。
+ */
+export const resolveDatabaseSchema = (environment: DatabaseEnvironment): string => {
+  const schema = environment.DB_SCHEMA;
+
+  if (environment.VERCEL_ENV === 'preview' && !previewSchemaPattern.test(schema ?? '')) {
+    throw new Error(
+      'Vercel Preview環境では、DB_SCHEMA に preview_pr_<PR番号> 形式のスキーマ名を設定してください。',
+    );
+  }
+
+  return schema ?? 'public';
+};

--- a/packages/dao/src/index.ts
+++ b/packages/dao/src/index.ts
@@ -1,5 +1,6 @@
 // 1. DataSource オプションをエクスポート
 export { commonDataSourceOptions } from './data-source';
+export { resolveDatabaseSchema } from './database-schema';
 export type { DataSourceOptions } from 'typeorm'; // 必要ならTypeORMの型も再エクスポート
 
 // 2. Entity をエクスポート

--- a/scripts/cleanup-stale-preview-deployments.js
+++ b/scripts/cleanup-stale-preview-deployments.js
@@ -1,0 +1,221 @@
+const VERCEL_API_BASE_URL = 'https://api.vercel.com';
+const DEPLOYMENTS_PAGE_SIZE = 100;
+
+const usage = `使用方法:
+  node scripts/cleanup-stale-preview-deployments.js [--before YYYY-MM-DD] [--keep-branch ブランチ名] [--execute]
+
+必要な環境変数:
+  VERCEL_TOKEN       Vercelのアクセストークン
+  VERCEL_ORG_ID      VercelのチームID
+  VERCEL_PROJECT_IDS カンマ区切りのVercelプロジェクトID
+
+既定では削除せず、対象一覧だけを表示します。
+削除するには --before と --execute を併用してください。`;
+
+const parseArguments = (arguments_) => {
+  const options = {
+    execute: false,
+    keepBranches: [],
+  };
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+
+    if (argument === '--execute') {
+      options.execute = true;
+      continue;
+    }
+
+    if (argument === '--before' || argument === '--keep-branch') {
+      const value = arguments_[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${argument} の値を指定してください。`);
+      }
+
+      if (argument === '--before') {
+        if (options.before) {
+          throw new Error('--before は1回だけ指定してください。');
+        }
+        options.before = value;
+      } else {
+        options.keepBranches.push(value);
+      }
+
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--help' || argument === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`不明なオプションです: ${argument}`);
+  }
+
+  if (options.before && Number.isNaN(Date.parse(options.before))) {
+    throw new Error('--before には YYYY-MM-DD またはISO 8601形式の日時を指定してください。');
+  }
+
+  if (options.execute && !options.before) {
+    throw new Error('削除するには --before を指定してください。');
+  }
+
+  return options;
+};
+
+const getRequiredEnvironment = () => {
+  const requiredEnvironmentVariables = ['VERCEL_ORG_ID', 'VERCEL_PROJECT_IDS', 'VERCEL_TOKEN'];
+  const missingVariables = requiredEnvironmentVariables.filter((name) => !process.env[name]);
+
+  if (missingVariables.length > 0) {
+    throw new Error(`必要な環境変数が設定されていません: ${missingVariables.join(', ')}`);
+  }
+
+  const projectIds = process.env.VERCEL_PROJECT_IDS
+    .split(',')
+    .map((projectId) => projectId.trim())
+    .filter(Boolean);
+
+  if (projectIds.length === 0) {
+    throw new Error('VERCEL_PROJECT_IDS に削除対象のプロジェクトIDを設定してください。');
+  }
+
+  return {
+    projectIds,
+    teamId: process.env.VERCEL_ORG_ID,
+    token: process.env.VERCEL_TOKEN,
+  };
+};
+
+const requestVercelApi = async (path, token, options = {}) => {
+  const response = await fetch(`${VERCEL_API_BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Vercel API request failed (${response.status}): ${await response.text()}`);
+  }
+
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  return response.json();
+};
+
+const listProjectDeployments = async ({ projectId, teamId, token }) => {
+  const deployments = [];
+  let until;
+
+  do {
+    const searchParams = new URLSearchParams({
+      projectId,
+      teamId,
+      limit: String(DEPLOYMENTS_PAGE_SIZE),
+    });
+
+    if (until) {
+      searchParams.set('until', String(until));
+    }
+
+    const result = await requestVercelApi(`/v6/deployments?${searchParams}`, token);
+    deployments.push(...(result.deployments ?? []));
+    until = result.pagination?.next;
+  } while (until);
+
+  return deployments;
+};
+
+const getDeploymentCreatedAt = (deployment) => {
+  const createdAt = deployment.createdAt ?? deployment.created;
+  const timestamp = typeof createdAt === 'number' ? createdAt : Date.parse(createdAt ?? '');
+
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+};
+
+const isPreviewDeployment = (deployment) => (
+  deployment.target === null || typeof deployment.target === 'undefined'
+);
+
+const shouldDeleteDeployment = (deployment, options) => {
+  if (!isPreviewDeployment(deployment)) {
+    return false;
+  }
+
+  if (options.keepBranches.includes(deployment.meta?.githubCommitRef)) {
+    return false;
+  }
+
+  if (!options.before) {
+    return true;
+  }
+
+  const createdAt = getDeploymentCreatedAt(deployment);
+  return createdAt !== undefined && createdAt < Date.parse(options.before);
+};
+
+const formatDeployment = (deployment) => {
+  const createdAt = getDeploymentCreatedAt(deployment);
+  const createdAtLabel = createdAt ? new Date(createdAt).toISOString() : '日時不明';
+  const branch = deployment.meta?.githubCommitRef ?? 'ブランチ情報なし';
+
+  return `${createdAtLabel}  ${branch}  ${deployment.url ?? deployment.uid}`;
+};
+
+const deleteDeployment = async ({ deployment, teamId, token }) => {
+  console.log(`Preview デプロイを削除します: ${deployment.uid} (${deployment.url})`);
+  await requestVercelApi(`/v13/deployments/${deployment.uid}?teamId=${encodeURIComponent(teamId)}`, token, {
+    method: 'DELETE',
+  });
+};
+
+const main = async () => {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage);
+    return;
+  }
+
+  const { projectIds, teamId, token } = getRequiredEnvironment();
+  const deploymentsByProject = await Promise.all(projectIds.map(async (projectId) => ({
+    projectId,
+    deployments: await listProjectDeployments({ projectId, teamId, token }),
+  })));
+
+  const candidates = deploymentsByProject.flatMap(({ projectId, deployments }) => deployments
+    .filter((deployment) => shouldDeleteDeployment(deployment, options))
+    .map((deployment) => ({ ...deployment, projectId })));
+
+  const mode = options.execute ? '削除実行' : 'Dry Run（削除しません）';
+  console.log(`${mode}: ${candidates.length}件のPreviewデプロイが対象です。`);
+  for (const deployment of candidates) {
+    console.log(`[${deployment.projectId}] ${formatDeployment(deployment)}`);
+  }
+
+  if (!options.execute || candidates.length === 0) {
+    return;
+  }
+
+  for (const deployment of candidates) {
+    await deleteDeployment({ deployment, teamId, token });
+  }
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  getDeploymentCreatedAt,
+  isPreviewDeployment,
+  parseArguments,
+  shouldDeleteDeployment,
+};

--- a/scripts/cleanup-stale-preview-deployments.test.js
+++ b/scripts/cleanup-stale-preview-deployments.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseArguments,
+  shouldDeleteDeployment,
+} = require('./cleanup-stale-preview-deployments');
+
+const previewDeployment = {
+  target: null,
+  created: Date.parse('2026-06-01T00:00:00.000Z'),
+  meta: {
+    githubCommitRef: 'closed-pr-branch',
+  },
+};
+
+test('削除実行には期限指定を必須にする', () => {
+  assert.throws(() => parseArguments(['--execute']), /--before/);
+  assert.deepEqual(
+    parseArguments(['--before', '2026-07-01', '--keep-branch', 'active-pr', '--execute']),
+    {
+      before: '2026-07-01',
+      execute: true,
+      keepBranches: ['active-pr'],
+    },
+  );
+});
+
+test('期限より古いPreviewだけを対象にし、Productionと除外ブランチを残す', () => {
+  const options = {
+    before: '2026-07-01',
+    keepBranches: [],
+  };
+
+  assert.equal(shouldDeleteDeployment(previewDeployment, options), true);
+  assert.equal(
+    shouldDeleteDeployment({ ...previewDeployment, target: 'production' }, options),
+    false,
+  );
+  assert.equal(
+    shouldDeleteDeployment(previewDeployment, { ...options, keepBranches: ['closed-pr-branch'] }),
+    false,
+  );
+});

--- a/scripts/delete-preview-deployments.js
+++ b/scripts/delete-preview-deployments.js
@@ -1,0 +1,118 @@
+const VERCEL_API_BASE_URL = 'https://api.vercel.com';
+const DEPLOYMENTS_PAGE_SIZE = 100;
+
+const requiredEnvironmentVariables = [
+  'PR_NUMBER',
+  'VERCEL_ORG_ID',
+  'VERCEL_PROJECT_IDS',
+  'VERCEL_TOKEN',
+];
+
+const getRequiredEnvironment = () => {
+  const missingVariables = requiredEnvironmentVariables.filter((name) => !process.env[name]);
+
+  if (missingVariables.length > 0) {
+    throw new Error(`必要な環境変数が設定されていません: ${missingVariables.join(', ')}`);
+  }
+
+  return {
+    prNumber: process.env.PR_NUMBER,
+    teamId: process.env.VERCEL_ORG_ID,
+    projectIds: process.env.VERCEL_PROJECT_IDS.split(',').map((projectId) => projectId.trim()).filter(Boolean),
+    token: process.env.VERCEL_TOKEN,
+  };
+};
+
+const isPreviewDeployment = (deployment) => (
+  deployment.target === null || typeof deployment.target === 'undefined'
+);
+
+const isTargetPreviewDeployment = (deployment, prNumber) => (
+  isPreviewDeployment(deployment)
+  && deployment.meta?.githubDeployment === '1'
+  && deployment.meta?.githubPullRequestId === prNumber
+);
+
+const requestVercelApi = async (path, token, options = {}) => {
+  const response = await fetch(`${VERCEL_API_BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Vercel API request failed (${response.status}): ${await response.text()}`);
+  }
+
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  return response.json();
+};
+
+const listProjectDeployments = async ({ projectId, teamId, token }) => {
+  const deployments = [];
+  let until;
+
+  do {
+    const searchParams = new URLSearchParams({
+      projectId,
+      teamId,
+      limit: String(DEPLOYMENTS_PAGE_SIZE),
+    });
+
+    if (until) {
+      searchParams.set('until', String(until));
+    }
+
+    const result = await requestVercelApi(`/v6/deployments?${searchParams}`, token);
+    deployments.push(...(result.deployments ?? []));
+    until = result.pagination?.next;
+  } while (until);
+
+  return deployments;
+};
+
+const deleteProjectPreviewDeployments = async ({ projectId, prNumber, teamId, token }) => {
+  const deployments = await listProjectDeployments({ projectId, teamId, token });
+  const previewDeployments = deployments.filter((deployment) => isTargetPreviewDeployment(deployment, prNumber));
+
+  if (previewDeployments.length === 0) {
+    console.log(`PR #${prNumber} に紐づく Preview デプロイは ${projectId} にありません。`);
+    return;
+  }
+
+  for (const deployment of previewDeployments) {
+    console.log(`Preview デプロイを削除します: ${deployment.uid} (${deployment.url})`);
+    await requestVercelApi(`/v13/deployments/${deployment.uid}?teamId=${encodeURIComponent(teamId)}`, token, {
+      method: 'DELETE',
+    });
+  }
+};
+
+const main = async () => {
+  const { prNumber, projectIds, teamId, token } = getRequiredEnvironment();
+
+  if (projectIds.length === 0) {
+    throw new Error('VERCEL_PROJECT_IDS に削除対象のプロジェクトIDを設定してください。');
+  }
+
+  for (const projectId of projectIds) {
+    await deleteProjectPreviewDeployments({ projectId, prNumber, teamId, token });
+  }
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  isPreviewDeployment,
+  isTargetPreviewDeployment,
+};

--- a/scripts/delete-preview-deployments.test.js
+++ b/scripts/delete-preview-deployments.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isTargetPreviewDeployment } = require('./delete-preview-deployments');
+
+test('同じPR番号を持つGitHub Previewデプロイだけを削除対象にする', () => {
+  assert.equal(
+    isTargetPreviewDeployment({
+      target: null,
+      meta: {
+        githubDeployment: '1',
+        githubPullRequestId: '142',
+      },
+    }, '142'),
+    true,
+  );
+});
+
+test('本番デプロイと別PRのデプロイは削除対象にしない', () => {
+  assert.equal(
+    isTargetPreviewDeployment({
+      target: 'production',
+      meta: {
+        githubDeployment: '1',
+        githubPullRequestId: '142',
+      },
+    }, '142'),
+    false,
+  );
+
+  assert.equal(
+    isTargetPreviewDeployment({
+      target: 'staging',
+      meta: {
+        githubDeployment: '1',
+        githubPullRequestId: '142',
+      },
+    }, '142'),
+    false,
+  );
+
+  assert.equal(
+    isTargetPreviewDeployment({
+      target: null,
+      meta: {
+        githubDeployment: '1',
+        githubPullRequestId: '141',
+      },
+    }, '142'),
+    false,
+  );
+});


### PR DESCRIPTION
## 概要

Vercel Previewが本番DBの`public`スキーマへフォールバックしないようにし、PRクローズ後に残るPreviewデプロイも削除するようにします。

## 変更内容

- Preview実行時に`DB_SCHEMA=preview_pr_<PR番号>`でなければアプリを起動失敗にするガードを追加
- PRクローズ時、該当PRのVercel Previewを削除してから専用DBスキーマを削除
- 過去のPreviewを期限・除外ブランチ付きでDry Run／明示削除できる運用スクリプトを追加
- Preview運用手順とユニットテストを追加

## 原因

PRクローズ時にPreview用DBスキーマだけが削除され、Vercel Previewデプロイ自体は残っていました。さらに`DB_SCHEMA`が未設定の場合、DB接続が`public`へフォールバックする実装でした。

## 検証

- `yarn test:unit`
- `tsc -p app/iba-cast-gallery/tsconfig.json --noEmit --incremental false`
- `tsc -p app/tweet-tagger/tsconfig.json --noEmit --incremental false`
- `git diff --check`
