### PR TITLE
IBAだいありぃBLOGの登録・表示機能を追加

### DIFF
--- a/app/iba-cast-gallery/next.config.ts
+++ b/app/iba-cast-gallery/next.config.ts
@@ -9,6 +9,15 @@ const nextConfig: NextConfig = {
     "@iba-cast-gallery/dao",
     "@iba-cast-gallery/types"
   ],
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "pbs.twimg.com",
+        pathname: "/**",
+      },
+    ],
+  },
   experimental: {
     serverActions:{
       allowedOrigins: allowedOrigins

--- a/app/iba-cast-gallery/src/app/blog/page.tsx
+++ b/app/iba-cast-gallery/src/app/blog/page.tsx
@@ -1,0 +1,41 @@
+import { Box, Typography } from "@mui/material";
+import { getActiveCasts } from "services/castService";
+import { getExistsBlogPosts } from "services/postService";
+import type { CastDto, PostWithCastsDto } from "@iba-cast-gallery/types";
+import BlogPosts from "components/BlogPosts";
+
+export const dynamic = "force-dynamic";
+
+export default async function BlogPage() {
+  const [casts, posts] = await Promise.all([
+    getActiveCasts(),
+    getExistsBlogPosts(),
+  ]);
+  const joinedPosts: PostWithCastsDto[] = posts.map((post) => ({
+    id: post.id,
+    postedAt: post.postedAt,
+    contentType: post.contentType,
+    taggedCasts: post.taggedCasts
+      .map((tag) => ({
+        order: tag.order,
+        cast: casts.find((cast) => cast.id === tag.castId),
+      }))
+      .filter((tag): tag is { order: number; cast: CastDto } => tag.cast !== undefined),
+  }));
+
+  return (
+    <Box className="w-full">
+      <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
+        IBAだいありぃ BLOG
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        IBAだいありぃで紹介されたキャストのBLOGポストです。
+      </Typography>
+      {joinedPosts.length > 0 ? (
+        <BlogPosts posts={joinedPosts} />
+      ) : (
+        <Typography color="text.secondary">BLOGポストはまだありません。</Typography>
+      )}
+    </Box>
+  );
+}

--- a/app/iba-cast-gallery/src/app/casts/[castEnName]/page.tsx
+++ b/app/iba-cast-gallery/src/app/casts/[castEnName]/page.tsx
@@ -8,11 +8,12 @@ import {
   AccordionDetails,
 } from "@mui/material";
 import { getCastDetail } from "services/castService";
-import Tweets from "../../../components/Tweets";
 import { Tweet } from "components/tweet/swr";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FanMark from "../../../components/FanMark";
 import dayjs from "dayjs";
+import { PostContentType, PostWithCastsDto } from "@iba-cast-gallery/types";
+import CastPostTabs from "components/CastPostTabs";
 
 export default async function Page({
   params,
@@ -22,11 +23,12 @@ export default async function Page({
   const castEnName = await params.then((p) => p.castEnName);
   const cast = await getCastDetail(castEnName);
 
-  const joinedPosts: JoinedPost[] = cast.taggedPosts
+  const joinedPosts: PostWithCastsDto[] = cast.taggedPosts
     .map((post) => {
       return {
         id: post.id,
         postedAt: post.postedAt,
+        contentType: post.contentType,
         taggedCasts: post.taggedCasts,
       };
     })
@@ -70,7 +72,14 @@ export default async function Page({
         ポスト一覧
       </Typography>
 
-      <Tweets joinedPosts={joinedPosts} />
+      <CastPostTabs
+        galleryPosts={joinedPosts.filter(
+          (post) => post.contentType === PostContentType.GALLERY,
+        )}
+        blogPosts={joinedPosts.filter(
+          (post) => post.contentType === PostContentType.BLOG,
+        )}
+      />
     </Box>
   );
 }

--- a/app/iba-cast-gallery/src/app/client-components/MenuDrawer.tsx
+++ b/app/iba-cast-gallery/src/app/client-components/MenuDrawer.tsx
@@ -66,6 +66,11 @@ const MenuDrawer = ({ open, setOpen }: MenuDrawerProps) => {
                                 <ListItemText primary="このサイトについて" />
                             </ListItemButton>
                         </ListItem>
+                        <ListItem>
+                            <ListItemButton href="/blog" onClick={() => setOpen(false)}>
+                                <ListItemText primary="IBAだいありぃ BLOG" />
+                            </ListItemButton>
+                        </ListItem>
 
                         <ListItem>
                             <ListItemButton onClick={toggleCastList}>

--- a/app/iba-cast-gallery/src/app/page.tsx
+++ b/app/iba-cast-gallery/src/app/page.tsx
@@ -19,6 +19,7 @@ export default async function Home () {
     return {
       id: post.id,
       postedAt: post.postedAt,
+      contentType: post.contentType,
       taggedCasts: taggedCasts,
     };
   });

--- a/app/iba-cast-gallery/src/components/BlogPostCard.tsx
+++ b/app/iba-cast-gallery/src/components/BlogPostCard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { ArticleOutlined, OpenInNew } from "@mui/icons-material";
+import Image from "next/image";
 import {
+  Box,
   Button,
   Card,
   CardActions,
@@ -15,6 +17,7 @@ import dayjs from "dayjs";
 import type { PostWithCastsDto } from "@iba-cast-gallery/types";
 import CastChip from "components/CastChip";
 import { useTweet } from "components/tweet/hooks";
+import { getMediaUrl } from "components/tweet/utils";
 
 const getPostUrl = (postId: string) =>
   `https://x.com/IBA_diary/status/${postId}`;
@@ -25,6 +28,8 @@ const getPostUrl = (postId: string) =>
 export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
   const { data: tweet, error, isLoading } = useTweet(post.id);
   const publishedAt = dayjs(post.postedAt).format("YYYY年M月D日");
+  const photos =
+    tweet?.mediaDetails?.filter((media) => media.type === "photo") ?? [];
 
   return (
     <Card
@@ -41,7 +46,52 @@ export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
           <Typography variant="subtitle2" color="text.secondary">
             {publishedAt}
           </Typography>
-          {isLoading && <Skeleton variant="text" height={84} />}
+          {isLoading && (
+            <>
+              <Skeleton variant="rectangular" height={240} sx={{ borderRadius: 1 }} />
+              <Skeleton variant="text" height={84} />
+            </>
+          )}
+          {!isLoading && photos.length > 0 && (
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns:
+                  photos.length === 1 ? "1fr" : "repeat(2, minmax(0, 1fr))",
+                gap: 0.5,
+              }}
+            >
+              {photos.map((photo, index) => (
+                <Box
+                  key={photo.media_url_https}
+                  component="a"
+                  href={getMediaUrl(photo, "large")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{
+                    aspectRatio: `${photo.original_info.width} / ${photo.original_info.height}`,
+                    borderRadius: 1,
+                    display: "block",
+                    overflow: "hidden",
+                    position: "relative",
+                  }}
+                >
+                  <Image
+                    src={getMediaUrl(photo, "medium")}
+                    alt={photo.ext_alt_text || `${publishedAt}のBLOG画像 ${index + 1}`}
+                    data-testid={`blog-post-image-${post.id}-${index}`}
+                    fill
+                    sizes={
+                      photos.length === 1
+                        ? "(max-width: 900px) 100vw, 33vw"
+                        : "(max-width: 900px) 50vw, 17vw"
+                    }
+                    style={{ objectFit: "cover" }}
+                  />
+                </Box>
+              ))}
+            </Box>
+          )}
           {!isLoading && tweet && (
             <Typography
               variant="body1"

--- a/app/iba-cast-gallery/src/components/BlogPostCard.tsx
+++ b/app/iba-cast-gallery/src/components/BlogPostCard.tsx
@@ -17,6 +17,7 @@ import {
 import dayjs from "dayjs";
 import { PhotoProvider, PhotoView } from "react-photo-view";
 import "react-photo-view/dist/react-photo-view.css";
+import { useEffect, useRef, useState } from "react";
 import type { PostWithCastsDto } from "@iba-cast-gallery/types";
 import CastChip from "components/CastChip";
 import { useTweet } from "components/tweet/hooks";
@@ -31,8 +32,35 @@ const getPostUrl = (postId: string) =>
 export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
   const { data: tweet, error, isLoading } = useTweet(post.id);
   const publishedAt = dayjs(post.postedAt).format("YYYY年M月D日");
+  const textRef = useRef<HTMLParagraphElement>(null);
+  const [isTextExpanded, setIsTextExpanded] = useState(false);
+  const [hasHiddenText, setHasHiddenText] = useState(false);
   const photos =
     tweet?.mediaDetails?.filter((media) => media.type === "photo") ?? [];
+
+  useEffect(() => {
+    setIsTextExpanded(false);
+  }, [tweet?.text]);
+
+  useEffect(() => {
+    if (!tweet?.text || isTextExpanded) {
+      return;
+    }
+
+    const textElement = textRef.current;
+    if (!textElement) {
+      return;
+    }
+
+    const updateHasHiddenText = () => {
+      setHasHiddenText(textElement.scrollHeight > textElement.clientHeight);
+    };
+
+    updateHasHiddenText();
+    const resizeObserver = new ResizeObserver(updateHasHiddenText);
+    resizeObserver.observe(textElement);
+    return () => resizeObserver.disconnect();
+  }, [isTextExpanded, tweet?.text]);
 
   return (
     <Card
@@ -57,12 +85,31 @@ export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
           )}
           {!isLoading && tweet && (
             <Typography
+              ref={textRef}
               variant="body1"
               component="p"
-              sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word", m: 0 }}
+              sx={{
+                display: isTextExpanded ? "block" : "-webkit-box",
+                m: 0,
+                overflow: "hidden",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp: isTextExpanded ? "unset" : 6,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
             >
               {tweet.text}
             </Typography>
+          )}
+          {!isLoading && tweet && hasHiddenText && (
+            <Button
+              size="small"
+              onClick={() => setIsTextExpanded((current) => !current)}
+              data-testid={`blog-post-expand-${post.id}`}
+              sx={{ alignSelf: "flex-start", px: 0 }}
+            >
+              {isTextExpanded ? "閉じる" : "続きを見る"}
+            </Button>
           )}
           {!isLoading && (!tweet || error) && (
             <Typography variant="body2" color="text.secondary">

--- a/app/iba-cast-gallery/src/components/BlogPostCard.tsx
+++ b/app/iba-cast-gallery/src/components/BlogPostCard.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ArticleOutlined, OpenInNew } from "@mui/icons-material";
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@mui/material";
+import dayjs from "dayjs";
+import type { PostWithCastsDto } from "@iba-cast-gallery/types";
+import CastChip from "components/CastChip";
+import { useTweet } from "components/tweet/hooks";
+
+const getPostUrl = (postId: string) =>
+  `https://x.com/IBA_diary/status/${postId}`;
+
+/**
+ * IBAだいありぃのBLOGポストを、画像ギャラリーとは別のテキスト中心カードで表示する。
+ */
+export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
+  const { data: tweet, error, isLoading } = useTweet(post.id);
+  const publishedAt = dayjs(post.postedAt).format("YYYY年M月D日");
+
+  return (
+    <Card
+      variant="outlined"
+      data-testid={`blog-post-card-${post.id}`}
+      sx={{ height: "100%", display: "flex", flexDirection: "column" }}
+    >
+      <CardContent sx={{ flexGrow: 1 }}>
+        <Stack spacing={1.5}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <ArticleOutlined color="primary" fontSize="small" />
+            <Chip label="IBAだいありぃ BLOG" color="primary" size="small" />
+          </Stack>
+          <Typography variant="subtitle2" color="text.secondary">
+            {publishedAt}
+          </Typography>
+          {isLoading && <Skeleton variant="text" height={84} />}
+          {!isLoading && tweet && (
+            <Typography
+              variant="body1"
+              component="p"
+              sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word", m: 0 }}
+            >
+              {tweet.text}
+            </Typography>
+          )}
+          {!isLoading && (!tweet || error) && (
+            <Typography variant="body2" color="text.secondary">
+              BLOGポストの本文を取得できませんでした。Xで本文を確認できます。
+            </Typography>
+          )}
+          {post.taggedCasts.length > 0 && (
+            <Stack direction="row" spacing={0.5} useFlexGap flexWrap="wrap">
+              {post.taggedCasts
+                .sort((a, b) => a.order - b.order)
+                .map(({ cast, order }) => (
+                  <CastChip key={cast.id} cast={cast} dataTestId={`blog-cast-tag-${order}`} />
+                ))}
+            </Stack>
+          )}
+        </Stack>
+      </CardContent>
+      <CardActions>
+        <Button
+          component="a"
+          href={getPostUrl(post.id)}
+          target="_blank"
+          rel="noopener noreferrer"
+          endIcon={<OpenInNew />}
+          size="small"
+        >
+          XでBLOGを読む
+        </Button>
+      </CardActions>
+    </Card>
+  );
+}

--- a/app/iba-cast-gallery/src/components/BlogPostCard.tsx
+++ b/app/iba-cast-gallery/src/components/BlogPostCard.tsx
@@ -9,11 +9,14 @@ import {
   CardActions,
   CardContent,
   Chip,
+  Paper,
   Skeleton,
   Stack,
   Typography,
 } from "@mui/material";
 import dayjs from "dayjs";
+import { PhotoProvider, PhotoView } from "react-photo-view";
+import "react-photo-view/dist/react-photo-view.css";
 import type { PostWithCastsDto } from "@iba-cast-gallery/types";
 import CastChip from "components/CastChip";
 import { useTweet } from "components/tweet/hooks";
@@ -48,49 +51,9 @@ export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
           </Typography>
           {isLoading && (
             <>
-              <Skeleton variant="rectangular" height={240} sx={{ borderRadius: 1 }} />
               <Skeleton variant="text" height={84} />
+              <Skeleton variant="rectangular" height={240} sx={{ borderRadius: 1 }} />
             </>
-          )}
-          {!isLoading && photos.length > 0 && (
-            <Box
-              sx={{
-                display: "grid",
-                gridTemplateColumns:
-                  photos.length === 1 ? "1fr" : "repeat(2, minmax(0, 1fr))",
-                gap: 0.5,
-              }}
-            >
-              {photos.map((photo, index) => (
-                <Box
-                  key={photo.media_url_https}
-                  component="a"
-                  href={getMediaUrl(photo, "large")}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  sx={{
-                    aspectRatio: `${photo.original_info.width} / ${photo.original_info.height}`,
-                    borderRadius: 1,
-                    display: "block",
-                    overflow: "hidden",
-                    position: "relative",
-                  }}
-                >
-                  <Image
-                    src={getMediaUrl(photo, "medium")}
-                    alt={photo.ext_alt_text || `${publishedAt}のBLOG画像 ${index + 1}`}
-                    data-testid={`blog-post-image-${post.id}-${index}`}
-                    fill
-                    sizes={
-                      photos.length === 1
-                        ? "(max-width: 900px) 100vw, 33vw"
-                        : "(max-width: 900px) 50vw, 17vw"
-                    }
-                    style={{ objectFit: "cover" }}
-                  />
-                </Box>
-              ))}
-            </Box>
           )}
           {!isLoading && tweet && (
             <Typography
@@ -105,6 +68,75 @@ export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
             <Typography variant="body2" color="text.secondary">
               BLOGポストの本文を取得できませんでした。Xで本文を確認できます。
             </Typography>
+          )}
+          {!isLoading && photos.length > 0 && (
+            <PhotoProvider
+              overlayRender={({ index }) => {
+                const photo = photos.at(index);
+                if (!photo?.ext_alt_text) {
+                  return null;
+                }
+
+                return (
+                  <Paper
+                    sx={{
+                      backgroundColor: "rgba(0, 0, 0, 0.6)",
+                      bottom: 0,
+                      p: 3,
+                      position: "absolute",
+                      width: "100%",
+                      zIndex: 10,
+                    }}
+                  >
+                    <Typography>{photo.ext_alt_text}</Typography>
+                  </Paper>
+                );
+              }}
+            >
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns:
+                    photos.length === 1 ? "1fr" : "repeat(2, minmax(0, 1fr))",
+                  gap: 0.5,
+                }}
+              >
+                {photos.map((photo, index) => (
+                  <PhotoView key={photo.media_url_https} src={getMediaUrl(photo, "large")}>
+                    <Box
+                      component="button"
+                      type="button"
+                      aria-label={`${publishedAt}のBLOG画像 ${index + 1}を拡大表示`}
+                      sx={{
+                        aspectRatio: `${photo.original_info.width} / ${photo.original_info.height}`,
+                        backgroundColor: "transparent",
+                        border: 0,
+                        borderRadius: 1,
+                        cursor: "zoom-in",
+                        display: "block",
+                        overflow: "hidden",
+                        p: 0,
+                        position: "relative",
+                        width: "100%",
+                      }}
+                    >
+                      <Image
+                        src={getMediaUrl(photo, "medium")}
+                        alt={photo.ext_alt_text || `${publishedAt}のBLOG画像 ${index + 1}`}
+                        data-testid={`blog-post-image-${post.id}-${index}`}
+                        fill
+                        sizes={
+                          photos.length === 1
+                            ? "(max-width: 900px) 100vw, 33vw"
+                            : "(max-width: 900px) 50vw, 17vw"
+                        }
+                        style={{ objectFit: "cover" }}
+                      />
+                    </Box>
+                  </PhotoView>
+                ))}
+              </Box>
+            </PhotoProvider>
           )}
           {post.taggedCasts.length > 0 && (
             <Stack direction="row" spacing={0.5} useFlexGap flexWrap="wrap">

--- a/app/iba-cast-gallery/src/components/BlogPostCard.tsx
+++ b/app/iba-cast-gallery/src/components/BlogPostCard.tsx
@@ -17,14 +17,22 @@ import {
 import dayjs from "dayjs";
 import { PhotoProvider, PhotoView } from "react-photo-view";
 import "react-photo-view/dist/react-photo-view.css";
-import { useEffect, useRef, useState } from "react";
+import { useTweet } from "react-tweet";
 import type { PostWithCastsDto } from "@iba-cast-gallery/types";
 import CastChip from "components/CastChip";
-import { useTweet } from "components/tweet/hooks";
 import { getMediaUrl } from "components/tweet/utils";
 
 const getPostUrl = (postId: string) =>
   `https://x.com/IBA_diary/status/${postId}`;
+
+type TweetWithNote = {
+  note_tweet?: {
+    id?: string;
+  };
+};
+
+const hasUnfetchedContinuation = (tweet: unknown) =>
+  typeof (tweet as TweetWithNote | undefined)?.note_tweet?.id === "string";
 
 /**
  * IBAだいありぃのBLOGポストを、画像ギャラリーとは別のテキスト中心カードで表示する。
@@ -32,35 +40,9 @@ const getPostUrl = (postId: string) =>
 export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
   const { data: tweet, error, isLoading } = useTweet(post.id);
   const publishedAt = dayjs(post.postedAt).format("YYYY年M月D日");
-  const textRef = useRef<HTMLParagraphElement>(null);
-  const [isTextExpanded, setIsTextExpanded] = useState(false);
-  const [hasHiddenText, setHasHiddenText] = useState(false);
   const photos =
     tweet?.mediaDetails?.filter((media) => media.type === "photo") ?? [];
-
-  useEffect(() => {
-    setIsTextExpanded(false);
-  }, [tweet?.text]);
-
-  useEffect(() => {
-    if (!tweet?.text || isTextExpanded) {
-      return;
-    }
-
-    const textElement = textRef.current;
-    if (!textElement) {
-      return;
-    }
-
-    const updateHasHiddenText = () => {
-      setHasHiddenText(textElement.scrollHeight > textElement.clientHeight);
-    };
-
-    updateHasHiddenText();
-    const resizeObserver = new ResizeObserver(updateHasHiddenText);
-    resizeObserver.observe(textElement);
-    return () => resizeObserver.disconnect();
-  }, [isTextExpanded, tweet?.text]);
+  const hasContinuation = hasUnfetchedContinuation(tweet);
 
   return (
     <Card
@@ -85,15 +67,10 @@ export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
           )}
           {!isLoading && tweet && (
             <Typography
-              ref={textRef}
               variant="body1"
               component="p"
               sx={{
-                display: isTextExpanded ? "block" : "-webkit-box",
                 m: 0,
-                overflow: "hidden",
-                WebkitBoxOrient: "vertical",
-                WebkitLineClamp: isTextExpanded ? "unset" : 6,
                 whiteSpace: "pre-wrap",
                 wordBreak: "break-word",
               }}
@@ -101,14 +78,18 @@ export default function BlogPostCard({ post }: { post: PostWithCastsDto }) {
               {tweet.text}
             </Typography>
           )}
-          {!isLoading && tweet && hasHiddenText && (
+          {!isLoading && hasContinuation && (
             <Button
+              component="a"
+              href={getPostUrl(post.id)}
+              target="_blank"
+              rel="noopener noreferrer"
               size="small"
-              onClick={() => setIsTextExpanded((current) => !current)}
-              data-testid={`blog-post-expand-${post.id}`}
+              endIcon={<OpenInNew />}
+              data-testid={`blog-post-continue-${post.id}`}
               sx={{ alignSelf: "flex-start", px: 0 }}
             >
-              {isTextExpanded ? "閉じる" : "続きを見る"}
+              Xで続きを読む
             </Button>
           )}
           {!isLoading && (!tweet || error) && (

--- a/app/iba-cast-gallery/src/components/BlogPosts.tsx
+++ b/app/iba-cast-gallery/src/components/BlogPosts.tsx
@@ -1,0 +1,19 @@
+import { Grid } from "@mui/material";
+import type { PostWithCastsDto } from "@iba-cast-gallery/types";
+import BlogPostCard from "components/BlogPostCard";
+
+export default function BlogPosts({
+  posts,
+}: {
+  posts: PostWithCastsDto[];
+}) {
+  return (
+    <Grid container spacing={2} className="w-full">
+      {posts.map((post) => (
+        <Grid key={post.id} size={{ xs: 12, md: 6, lg: 4 }}>
+          <BlogPostCard post={post} />
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/app/iba-cast-gallery/src/components/CastPostTabs.tsx
+++ b/app/iba-cast-gallery/src/components/CastPostTabs.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Box, Tab, Tabs, Typography } from "@mui/material";
+import { useState } from "react";
+import type { PostWithCastsDto } from "@iba-cast-gallery/types";
+import BlogPosts from "components/BlogPosts";
+import Tweets from "components/Tweets";
+
+export default function CastPostTabs({
+  galleryPosts,
+  blogPosts,
+}: {
+  galleryPosts: PostWithCastsDto[];
+  blogPosts: PostWithCastsDto[];
+}) {
+  const [tab, setTab] = useState(0);
+
+  return (
+    <Box>
+      <Tabs
+        value={tab}
+        onChange={(_event, value: number) => setTab(value)}
+        aria-label="キャストのポスト種別"
+        sx={{ mb: 2 }}
+      >
+        <Tab label={`画像ポスト (${galleryPosts.length})`} id="cast-post-tab-0" />
+        <Tab label={`BLOG (${blogPosts.length})`} id="cast-post-tab-1" />
+      </Tabs>
+      <Box role="tabpanel" hidden={tab !== 0} aria-labelledby="cast-post-tab-0">
+        {tab === 0 && (
+          galleryPosts.length > 0 ? (
+            <Tweets joinedPosts={galleryPosts} />
+          ) : (
+            <Typography color="text.secondary">画像ポストはまだありません。</Typography>
+          )
+        )}
+      </Box>
+      <Box role="tabpanel" hidden={tab !== 1} aria-labelledby="cast-post-tab-1">
+        {tab === 1 && (
+          blogPosts.length > 0 ? (
+            <BlogPosts posts={blogPosts} />
+          ) : (
+            <Typography color="text.secondary">BLOGポストはまだありません。</Typography>
+          )
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/app/iba-cast-gallery/src/components/tweet/swr.tsx
+++ b/app/iba-cast-gallery/src/components/tweet/swr.tsx
@@ -8,7 +8,7 @@ import {
   type TwitterComponents,
 } from './twitter-theme/components'
 import { type TweetCoreProps } from './utils'
-import { useTweet } from './hooks'
+import { useTweet } from 'react-tweet'
 import type { CastDto } from '@iba-cast-gallery/types'
 
 export type TweetProps = Omit<TweetCoreProps, 'id'> & {

--- a/app/iba-cast-gallery/src/components/tweet/tweet.tsx
+++ b/app/iba-cast-gallery/src/components/tweet/tweet.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react'
-import { getTweet } from './api/index'
+import { getTweet } from 'react-tweet/api'
 import {
   EmbeddedTweet,
   TweetNotFound,

--- a/app/iba-cast-gallery/src/services/castService.ts
+++ b/app/iba-cast-gallery/src/services/castService.ts
@@ -35,10 +35,10 @@ export async function getActiveCasts(): Promise<CastDto[]> {
 
 // TODO ここに書くのが適切か検討したい
 export type CastDetailDto = Pick<CastDto, "id" | "name" | "enName" | "type" | "introduceTweetId" | "fanMark"> & {
-    taggedPosts: Array<Pick<PostDto, "id" | "postedAt"> & {
+    taggedPosts: Array<Pick<PostDto, "id" | "postedAt" | "contentType"> & {
         taggedCasts: {
             order: number;
-            cast: Pick<CastDto, "id" | "name" | "enName">
+            cast: CastDto
          }[];
     }>;
 };
@@ -97,6 +97,7 @@ export async function getCastDetail(castEnName: string): Promise<CastDetailDto> 
             return {
                 id: post.id,
                 postedAt: post.postedAt,
+                contentType: post.contentType,
                 taggedCasts: post.castTags.sort((a, b) => a.order - b.order).map((castTag) => (
                     {
                         order: castTag.order,
@@ -104,6 +105,10 @@ export async function getCastDetail(castEnName: string): Promise<CastDetailDto> 
                             id: castTag.cast.id,
                             name: castTag.cast.name,
                             enName: castTag.cast.enName,
+                            introduceTweetId: castTag.cast.introduceTweetId,
+                            type: castTag.cast.type,
+                            fanMark: castTag.cast.fanMark,
+                            taggedPosts: [],
                         }
                     }
                 )),

--- a/app/iba-cast-gallery/src/services/postService.ts
+++ b/app/iba-cast-gallery/src/services/postService.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import { initializeDatabase, appDataSource } from "data-source";
 import { Repository } from "@iba-cast-gallery/dao";
 import { Post } from "@iba-cast-gallery/dao";
-import { PostDto } from '@iba-cast-gallery/types';
+import { PostContentType, PostDto } from '@iba-cast-gallery/types';
 
 /**
  * 有効なポスト情報を全件取得する (postedAtの降順で返却)
@@ -15,6 +15,7 @@ export async function getExistsPosts(): Promise<PostDto[]> {
         where: {
             isDeleted: false,
             showInGallery: true,
+            contentType: PostContentType.GALLERY,
         },
         order: {
             postedAt: "DESC",
@@ -24,11 +25,41 @@ export async function getExistsPosts(): Promise<PostDto[]> {
     return posts.map((post) => ({
         id: post.id,
         postedAt: post.postedAt,
+        contentType: post.contentType,
         taggedCasts: post.castTags.sort((a, b) => a.order - b.order).map((castTag) => {
             return {
                 order: castTag.order,
                 castId: castTag.castid
             };
         }),
+    }));
+}
+
+/**
+ * 公開中の IBAだいありぃ BLOG ポストを投稿日降順で取得する。
+ */
+export async function getExistsBlogPosts(): Promise<PostDto[]> {
+    await initializeDatabase();
+
+    const postRepository: Repository<Post> = appDataSource.getRepository(Post);
+    const posts = await postRepository.find({
+        where: {
+            isDeleted: false,
+            showInGallery: true,
+            contentType: PostContentType.BLOG,
+        },
+        order: {
+            postedAt: "DESC",
+        },
+    });
+
+    return posts.map((post) => ({
+        id: post.id,
+        postedAt: post.postedAt,
+        contentType: post.contentType,
+        taggedCasts: post.castTags.sort((a, b) => a.order - b.order).map((castTag) => ({
+            order: castTag.order,
+            castId: castTag.castid,
+        })),
     }));
 }

--- a/app/iba-cast-gallery/src/services/userService.ts
+++ b/app/iba-cast-gallery/src/services/userService.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { initializeDatabase, appDataSource } from "data-source";
 import { Favorite, Repository } from "@iba-cast-gallery/dao";
 import { User, UserAccount } from "@iba-cast-gallery/dao";
-import { PostWithCastsDto } from '@iba-cast-gallery/types';
+import { PostContentType, PostWithCastsDto } from '@iba-cast-gallery/types';
 import { Post } from "@iba-cast-gallery/dao";
 
 /**
@@ -90,6 +90,9 @@ export async function getFavoritePosts(user:User): Promise<PostWithCastsDto[]> {
         .leftJoinAndSelect("castTag.cast", "cast")
         .where("post.id IN (:...postIds)", { postIds })
         .andWhere("post.show_in_gallery = true")
+        .andWhere("post.content_type = :contentType", {
+            contentType: PostContentType.GALLERY,
+        })
         .getMany();
 
     // お気に入り登録順になるように再マップ
@@ -99,6 +102,7 @@ export async function getFavoritePosts(user:User): Promise<PostWithCastsDto[]> {
     return orderedPosts.map((post) => ({
         id: post.id,
         postedAt: post.postedAt,
+        contentType: post.contentType,
         taggedCasts: post.castTags?.map((castTag) => ({
             order: castTag.order,
             cast: {

--- a/app/iba-cast-gallery/src/types/types.d.ts
+++ b/app/iba-cast-gallery/src/types/types.d.ts
@@ -2,6 +2,7 @@ declare global {
     interface JoinedPost {
         id: string;
         postedAt: string;
+        contentType: import("@iba-cast-gallery/types").PostContentType;
         taggedCasts: {
             order:number;
             cast:CastDto;

--- a/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
@@ -8,6 +8,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { Tweet } from "../../components/tweet/swr";
 import dayjs, { Dayjs } from "dayjs";
 import { Cast, Post, PostCastTag } from "@iba-cast-gallery/dao";
+import { PostContentType } from "@iba-cast-gallery/types";
 import { useRouter } from "next/navigation";
 import TagEditor from "./TagEditor";
 import { extractPostId, getPostCreatedAtFromId } from "utils/postId";
@@ -62,6 +63,7 @@ const TweetEditor = ({ initialId }: {
       postedAt: tweetDateTime?.toISOString(),
       isDeleted: isDeleted,
       showInGallery: true,
+      contentType: PostContentType.GALLERY,
       shiftSource: null,
       castTags: castTags,
       taggedCasts: [],

--- a/app/tweet-tagger/src/app/client-component/TweetList.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetList.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { Post } from "@iba-cast-gallery/dao";
+import { PostContentType } from "@iba-cast-gallery/types";
 import { Tweet } from "components/tweet/swr";
 import { Button, Chip, CircularProgress, Grid, Typography } from "@mui/material";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import BlogPostPreview from "../../components/BlogPostPreview";
 
 const TweetList = () => {
   const [posts, setPosts] = useState<Post[]>([]);
@@ -63,6 +65,8 @@ const TweetList = () => {
                 <Typography variant="body2" color="error">
                   削除済み
                 </Typography>
+              ) : post.contentType === PostContentType.BLOG ? (
+                <BlogPostPreview postId={post.id} postedAt={post.postedAt} />
               ) : (
                 <Tweet
                   id={post.id}

--- a/app/tweet-tagger/src/app/client-component/UnifiedTweetEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/UnifiedTweetEditor.tsx
@@ -29,6 +29,7 @@ import {
     inferShiftFromPostedAt,
     InferredShift,
 } from "../../utils/shift";
+import BlogPostPreview from "../../components/BlogPostPreview";
 
 const SHIFT_LABELS: Record<ShiftSlot, string> = {
     [ShiftSlot.OPEN]: "オープン",
@@ -41,6 +42,7 @@ type RegistrationDetailResponse = {
         postedAt: string;
         isDeleted: boolean;
         showInGallery: boolean;
+        contentType: "gallery" | "blog";
         shiftSource: string | null;
         castTags: { castid: number; order: number }[];
     };
@@ -70,6 +72,7 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
     const [taggedCastIds, setTaggedCastIds] = useState<number[]>([]);
     const [shiftCastIds, setShiftCastIds] = useState<number[]>([]);
     const [registerGallery, setRegisterGallery] = useState(true);
+    const [registerBlog, setRegisterBlog] = useState(false);
     const [registerShift, setRegisterShift] = useState(false);
     const [shiftDate, setShiftDate] = useState<Dayjs>(
         dayjs(initialShift.date),
@@ -146,9 +149,12 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
                 setIsDeleted(detail.post.isDeleted);
                 setTaggedCastIds(orderedTagIds);
                 setShowInGallery(detail.post.showInGallery);
+                const isBlog = detail.post.contentType === "blog";
+                setRegisterBlog(isBlog);
                 setRegisterGallery(
-                    detail.post.showInGallery ||
-                        detail.post.shiftSource === null,
+                    !isBlog &&
+                        (detail.post.showInGallery ||
+                            detail.post.shiftSource === null),
                 );
                 setRegisterShift(
                     detail.shift !== null ||
@@ -203,7 +209,7 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
             setErrorMessage("XのポストURLまたはポストIDを入力してください");
             return;
         }
-        if (!registerGallery && !registerShift) {
+        if (!registerGallery && !registerBlog && !registerShift) {
             setErrorMessage("登録先を1つ以上選択してください");
             return;
         }
@@ -226,9 +232,10 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
             isDeleted,
             destinations: {
                 gallery: registerGallery,
+                blog: registerBlog,
                 shift: registerShift,
             },
-            taggedCastIds: registerGallery ? taggedCastIds : [],
+            taggedCastIds: registerGallery || registerBlog ? taggedCastIds : [],
             shiftCastIds: registerShift
                 ? uniqueIds([...taggedCastIds, ...shiftCastIds])
                 : [],
@@ -252,7 +259,7 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
                 const error = await response.json().catch(() => null);
                 throw new Error(error?.error ?? "登録に失敗しました");
             }
-            if (registerGallery) {
+            if (registerGallery || registerBlog) {
                 setShowInGallery(true);
             }
             if (isEditing) {
@@ -267,6 +274,7 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
             setTaggedCastIds([]);
             setShiftCastIds([]);
             setRegisterGallery(true);
+            setRegisterBlog(false);
             setRegisterShift(false);
             setShiftDate(dayjs(nextShift.date));
             setShiftSlot(nextShift.slot);
@@ -291,10 +299,14 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
         normalizedPostId === null ||
         normalizedPostId !== tweetId ||
         !tweetDateTime?.isValid() ||
-        (!registerGallery && !registerShift) ||
+        (!registerGallery && !registerBlog && !registerShift) ||
         (registerShift && shiftCastIds.length === 0);
     const buttonLabel =
-        registerGallery && registerShift
+        registerBlog && registerShift
+            ? "BLOGとシフトに登録"
+            : registerBlog
+                ? "BLOGに登録"
+                : registerGallery && registerShift
             ? "ギャラリーとシフトに登録"
             : registerShift
                 ? "シフトに登録"
@@ -334,7 +346,14 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
                     htmlInput: { "data-testid": "tweet-id-input" },
                 }}
             />
-            <Tweet id={tweetId} taggedCasts={[]} />
+            {registerBlog ? (
+                <BlogPostPreview
+                    postId={normalizedPostId ?? ""}
+                    postedAt={tweetDateTime?.isValid() ? tweetDateTime.toISOString() : null}
+                />
+            ) : (
+                <Tweet id={tweetId} taggedCasts={[]} />
+            )}
 
             <Paper variant="outlined" sx={{ p: 2 }}>
                 <Typography variant="subtitle2">登録先</Typography>
@@ -345,6 +364,9 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
                                 checked={registerGallery}
                                 onChange={(_, checked) => {
                                     setRegisterGallery(checked);
+                                    if (checked) {
+                                        setRegisterBlog(false);
+                                    }
                                     if (checked && registerShift) {
                                         setShiftCastIds((current) =>
                                             uniqueIds([
@@ -362,6 +384,21 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
                     <FormControlLabel
                         control={
                             <Checkbox
+                                checked={registerBlog}
+                                onChange={(_, checked) => {
+                                    setRegisterBlog(checked);
+                                    if (checked) {
+                                        setRegisterGallery(false);
+                                    }
+                                }}
+                                data-testid="blog-destination-checkbox"
+                            />
+                        }
+                        label="BLOGに登録"
+                    />
+                    <FormControlLabel
+                        control={
+                            <Checkbox
                                 checked={registerShift}
                                 onChange={(_, checked) =>
                                     handleShiftDestinationChange(checked)
@@ -374,15 +411,15 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
                 </Stack>
             </Paper>
 
-            {registerGallery && (
+            {(registerGallery || registerBlog) && (
                 <Paper variant="outlined" sx={{ p: 2 }}>
                     <CastMultiSelect
                         casts={casts}
                         value={taggedCastIds}
                         onChange={handleTaggedCastsChange}
                         ordered
-                        label="写ってるキャストを選択"
-                        helperText="姿が写っているキャストだけを選びます。並び順はドラッグで変更できます。"
+                        label={registerBlog ? "タグ付けするキャストを選択" : "写ってるキャストを選択"}
+                        helperText={registerBlog ? "BLOGに登場するキャストを選びます。並び順はドラッグで変更できます。" : "姿が写っているキャストだけを選びます。並び順はドラッグで変更できます。"}
                         testId="cast-autocomplete"
                     />
                 </Paper>
@@ -417,7 +454,7 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
                                 )
                             }
                             fixedIds={
-                                registerGallery ? taggedCastIds : []
+                                registerGallery || registerBlog ? taggedCastIds : []
                             }
                             label="出勤中のキャストを選択"
                             helperText="写真タグのキャストは自動で含まれます。キャストボードにだけ載っているキャストを追加してください。"

--- a/app/tweet-tagger/src/app/client-component/UnifiedTweetEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/UnifiedTweetEditor.tsx
@@ -194,6 +194,7 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
     const handleShiftDestinationChange = (checked: boolean) => {
         setRegisterShift(checked);
         if (checked) {
+            setRegisterBlog(false);
             setShiftCastIds((current) =>
                 uniqueIds([...taggedCastIds, ...current]),
             );
@@ -302,11 +303,9 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
         (!registerGallery && !registerBlog && !registerShift) ||
         (registerShift && shiftCastIds.length === 0);
     const buttonLabel =
-        registerBlog && registerShift
-            ? "BLOGとシフトに登録"
-            : registerBlog
-                ? "BLOGに登録"
-                : registerGallery && registerShift
+        registerBlog
+            ? "BLOGに登録"
+            : registerGallery && registerShift
             ? "ギャラリーとシフトに登録"
             : registerShift
                 ? "シフトに登録"
@@ -389,6 +388,7 @@ const UnifiedTweetEditor = ({ initialId }: { initialId: string }) => {
                                     setRegisterBlog(checked);
                                     if (checked) {
                                         setRegisterGallery(false);
+                                        setRegisterShift(false);
                                     }
                                 }}
                                 data-testid="blog-destination-checkbox"

--- a/app/tweet-tagger/src/components/BlogPostPreview.tsx
+++ b/app/tweet-tagger/src/components/BlogPostPreview.tsx
@@ -1,8 +1,18 @@
 "use client";
 
 import { ArticleOutlined, OpenInNew } from "@mui/icons-material";
-import { Button, Card, CardActions, CardContent, Chip, Stack, Typography } from "@mui/material";
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@mui/material";
 import dayjs from "dayjs";
+import { useTweet } from "./tweet/hooks";
 
 export default function BlogPostPreview({
   postId,
@@ -12,6 +22,7 @@ export default function BlogPostPreview({
   postedAt: string | null;
 }) {
   const postUrl = postId ? `https://x.com/IBA_diary/status/${postId}` : undefined;
+  const { data: tweet, error, isLoading } = useTweet(postId || undefined);
 
   return (
     <Card variant="outlined" data-testid="blog-post-preview">
@@ -24,6 +35,27 @@ export default function BlogPostPreview({
           <Typography variant="body2" color="text.secondary">
             {postedAt ? dayjs(postedAt).format("YYYY年M月D日") : "投稿日時を入力してください"}
           </Typography>
+          {!postId && (
+            <Typography variant="body2" color="text.secondary">
+              XのポストURL または IDを入力すると、本文を確認できます。
+            </Typography>
+          )}
+          {postId && isLoading && <Skeleton variant="text" height={84} />}
+          {postId && !isLoading && tweet && (
+            <Typography
+              variant="body1"
+              component="p"
+              data-testid="blog-post-preview-text"
+              sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word", m: 0 }}
+            >
+              {tweet.text}
+            </Typography>
+          )}
+          {postId && !isLoading && (!tweet || error) && (
+            <Typography variant="body2" color="text.secondary">
+              ポスト本文を取得できませんでした。Xのポストを確認してください。
+            </Typography>
+          )}
           <Typography variant="body2">
             画像ギャラリーには載せず、BLOG一覧とタグ付けしたキャストのBLOGタブに表示されます。
           </Typography>

--- a/app/tweet-tagger/src/components/BlogPostPreview.tsx
+++ b/app/tweet-tagger/src/components/BlogPostPreview.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from "@mui/material";
 import dayjs from "dayjs";
-import { useTweet } from "./tweet/hooks";
+import { useTweet } from "react-tweet";
 
 export default function BlogPostPreview({
   postId,

--- a/app/tweet-tagger/src/components/BlogPostPreview.tsx
+++ b/app/tweet-tagger/src/components/BlogPostPreview.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ArticleOutlined, OpenInNew } from "@mui/icons-material";
+import { Button, Card, CardActions, CardContent, Chip, Stack, Typography } from "@mui/material";
+import dayjs from "dayjs";
+
+export default function BlogPostPreview({
+  postId,
+  postedAt,
+}: {
+  postId: string;
+  postedAt: string | null;
+}) {
+  const postUrl = postId ? `https://x.com/IBA_diary/status/${postId}` : undefined;
+
+  return (
+    <Card variant="outlined" data-testid="blog-post-preview">
+      <CardContent>
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <ArticleOutlined color="primary" fontSize="small" />
+            <Chip label="IBAだいありぃ BLOG" color="primary" size="small" />
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            {postedAt ? dayjs(postedAt).format("YYYY年M月D日") : "投稿日時を入力してください"}
+          </Typography>
+          <Typography variant="body2">
+            画像ギャラリーには載せず、BLOG一覧とタグ付けしたキャストのBLOGタブに表示されます。
+          </Typography>
+        </Stack>
+      </CardContent>
+      {postUrl && (
+        <CardActions>
+          <Button
+            component="a"
+            href={postUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="small"
+            endIcon={<OpenInNew />}
+          >
+            Xのポストを確認
+          </Button>
+        </CardActions>
+      )}
+    </Card>
+  );
+}

--- a/app/tweet-tagger/src/components/tweet/swr.tsx
+++ b/app/tweet-tagger/src/components/tweet/swr.tsx
@@ -8,7 +8,7 @@ import {
   type TwitterComponents,
 } from './twitter-theme/components'
 import { type TweetCoreProps } from './utils'
-import { useTweet } from './hooks'
+import { useTweet } from 'react-tweet'
 import { Cast } from "@iba-cast-gallery/dao";
 
 export type TweetProps = Omit<TweetCoreProps, 'id'> & {

--- a/app/tweet-tagger/src/components/tweet/tweet.tsx
+++ b/app/tweet-tagger/src/components/tweet/tweet.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react'
-import { getTweet } from './api/index'
+import { getTweet } from 'react-tweet/api'
 import {
   EmbeddedTweet,
   TweetNotFound,

--- a/app/tweet-tagger/src/services/postRegistrationService.ts
+++ b/app/tweet-tagger/src/services/postRegistrationService.ts
@@ -46,6 +46,11 @@ function validateRequest(request: PostRegistrationRequest) {
             "ギャラリーとBLOGを同時には登録できません",
         );
     }
+    if (isBlog && request.destinations?.shift) {
+        throw new PostRegistrationValidationError(
+            "BLOGとシフトを同時には登録できません",
+        );
+    }
     if (
         !Array.isArray(request.taggedCastIds) ||
         !Array.isArray(request.shiftCastIds)
@@ -75,7 +80,7 @@ function validateRequest(request: PostRegistrationRequest) {
         )
     ) {
         throw new PostRegistrationValidationError(
-            "コンテンツタグのキャストは出勤キャストにも含めてください",
+            "写真タグのキャストは出勤キャストにも含めてください",
         );
     }
     if (request.shift?.date && !isValidDateString(request.shift.date)) {

--- a/app/tweet-tagger/src/services/postRegistrationService.ts
+++ b/app/tweet-tagger/src/services/postRegistrationService.ts
@@ -2,6 +2,7 @@ import "server-only";
 import "reflect-metadata";
 import { Cast, Post, PostCastTag, Repository, Shift } from "@iba-cast-gallery/dao";
 import {
+    PostContentType,
     PostRegistrationRequest,
     PostRegistrationResult,
     ShiftSlot,
@@ -34,8 +35,16 @@ function validateRequest(request: PostRegistrationRequest) {
     if (extractPostId(request.postId) !== request.postId) {
         throw new PostRegistrationValidationError("ポストIDが不正です");
     }
-    if (!request.destinations?.gallery && !request.destinations?.shift) {
+    const isBlog = request.destinations?.blog === true;
+    const hasContentDestination = request.destinations?.gallery || isBlog;
+
+    if (!hasContentDestination && !request.destinations?.shift) {
         throw new PostRegistrationValidationError("登録先を1つ以上選択してください");
+    }
+    if (request.destinations?.gallery && isBlog) {
+        throw new PostRegistrationValidationError(
+            "ギャラリーとBLOGを同時には登録できません",
+        );
     }
     if (
         !Array.isArray(request.taggedCastIds) ||
@@ -59,14 +68,14 @@ function validateRequest(request: PostRegistrationRequest) {
         );
     }
     if (
-        request.destinations.gallery &&
+        hasContentDestination &&
         request.destinations.shift &&
         request.taggedCastIds.some(
             (castId) => !request.shiftCastIds.includes(castId),
         )
     ) {
         throw new PostRegistrationValidationError(
-            "写真タグのキャストは出勤キャストにも含めてください",
+            "コンテンツタグのキャストは出勤キャストにも含めてください",
         );
     }
     if (request.shift?.date && !isValidDateString(request.shift.date)) {
@@ -81,7 +90,7 @@ function validateRequest(request: PostRegistrationRequest) {
 }
 
 /**
- * ギャラリーのタグ付けとシフト登録を、選択された登録先だけまとめて保存する。
+ * ギャラリーまたはBLOGのタグ付けとシフト登録を、選択された登録先だけまとめて保存する。
  */
 export async function registerPostWithDestinations(
     request: PostRegistrationRequest,
@@ -89,7 +98,9 @@ export async function registerPostWithDestinations(
     validateRequest(request);
     await initializeDatabase();
 
-    const taggedCastIds = request.destinations.gallery
+    const isBlog = request.destinations.blog === true;
+    const hasContentDestination = request.destinations.gallery || isBlog;
+    const taggedCastIds = hasContentDestination
         ? uniqueIds(request.taggedCastIds)
         : [];
     const shiftCastIds = request.destinations.shift
@@ -139,9 +150,14 @@ export async function registerPostWithDestinations(
         const postValues = {
             postedAt,
             isDeleted: request.isDeleted ?? existing?.isDeleted ?? false,
-            showInGallery: request.destinations.gallery
+            showInGallery: hasContentDestination
                 ? true
                 : existing?.showInGallery ?? false,
+            contentType: hasContentDestination
+                ? isBlog
+                    ? PostContentType.BLOG
+                    : PostContentType.GALLERY
+                : existing?.contentType ?? PostContentType.GALLERY,
             shiftSource: request.destinations.shift
                 ? existing?.shiftSource === ShiftSourceStatus.DONE
                     ? ShiftSourceStatus.DONE
@@ -158,7 +174,7 @@ export async function registerPostWithDestinations(
             });
         }
 
-        if (request.destinations.gallery) {
+        if (hasContentDestination) {
             const postCastTagRepository: Repository<PostCastTag> =
                 em.getRepository(PostCastTag);
             await postCastTagRepository.delete({ postId: request.postId });
@@ -199,7 +215,7 @@ export async function registerPostWithDestinations(
                 shiftCastIds,
                 shift,
             },
-            "ポストのギャラリー・シフト登録完了",
+            "ポストのコンテンツ・シフト登録完了",
         );
 
         return {

--- a/app/tweet-tagger/src/services/postService.ts
+++ b/app/tweet-tagger/src/services/postService.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { initializeDatabase, appDataSource } from "../data-source";
 import { PostCastTag, Repository } from "@iba-cast-gallery/dao";
+import { PostContentType } from "@iba-cast-gallery/types";
 import { Post } from "@iba-cast-gallery/dao";
 import logger from "../logger";
 import { getPostCreatedAtFromId } from "utils/postId";
@@ -43,6 +44,7 @@ export async function registerPost(post: Post): Promise<void> {
                 postedAt: post.postedAt,
                 isDeleted: post.isDeleted,
                 showInGallery: post.showInGallery,
+                contentType: post.contentType,
                 shiftSource: post.shiftSource,
             });
             logger.info({post},`ポスト更新完了`);
@@ -91,6 +93,7 @@ export async function ensureDraftPost(postId: string): Promise<Post> {
             postedAt,
             isDeleted: false,
             showInGallery: false,
+            contentType: PostContentType.GALLERY,
             shiftSource: null,
         })
         .orIgnore()

--- a/e2e/blog-post-flow.spec.ts
+++ b/e2e/blog-post-flow.spec.ts
@@ -42,6 +42,9 @@ if (!taggedCast) {
                         json: {
                             data: {
                                 text: BLOG_POST_TEXT,
+                                note_tweet: {
+                                    id: "long-form-blog-post",
+                                },
                                 mediaDetails: [
                                     {
                                         type: "photo",
@@ -103,12 +106,14 @@ if (!taggedCast) {
             await expect(
                 page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
             ).toContainText(BLOG_POST_TEXT);
-            const expandButton = page.getByTestId(
-                `blog-post-expand-${BLOG_POST_ID}`,
+            const continueLink = page.getByTestId(
+                `blog-post-continue-${BLOG_POST_ID}`,
             );
-            await expect(expandButton).toHaveText("続きを見る");
-            await expandButton.click();
-            await expect(expandButton).toHaveText("閉じる");
+            await expect(continueLink).toHaveText("Xで続きを読む");
+            await expect(continueLink).toHaveAttribute(
+                "href",
+                `https://x.com/IBA_diary/status/${BLOG_POST_ID}`,
+            );
             await page.getByTestId(`blog-post-image-${BLOG_POST_ID}-0`).click();
             await expect(page.locator(".PhotoView-Portal")).toBeVisible();
             await page.keyboard.press("Escape");

--- a/e2e/blog-post-flow.spec.ts
+++ b/e2e/blog-post-flow.spec.ts
@@ -4,6 +4,7 @@ import { getTestCasts } from "./lib/test-data";
 const ADMIN_URL = "http://localhost:3001";
 const GALLERY_URL = "http://localhost:3000";
 const BLOG_POST_ID = "11647688710085046272";
+const BLOG_POST_TEXT = "登録前に確認できるBLOGポスト本文";
 
 const casts = getTestCasts();
 const taggedCast = casts[0] ?? null;
@@ -26,6 +27,28 @@ if (!taggedCast) {
         test("BLOGとして登録したポストをギャラリーから分離し、キャスト詳細で表示する", async ({
             page,
         }) => {
+            await page.route(
+                `https://react-tweet.vercel.app/api/tweet/${BLOG_POST_ID}`,
+                (route) =>
+                    route.fulfill({
+                        json: {
+                            data: {
+                                text: BLOG_POST_TEXT,
+                                mediaDetails: [
+                                    {
+                                        type: "photo",
+                                        media_url_https:
+                                            "https://pbs.twimg.com/media/blog-e2e.jpg",
+                                        original_info: {
+                                            height: 900,
+                                            width: 1200,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    }),
+            );
             await Promise.all([
                 page.goto(ADMIN_URL),
                 page.waitForResponse((response) =>
@@ -36,6 +59,9 @@ if (!taggedCast) {
             await page.getByTestId("gallery-destination-checkbox").uncheck();
             await page.getByTestId("blog-destination-checkbox").check();
             await expect(page.getByTestId("blog-post-preview")).toBeVisible();
+            await expect(page.getByTestId("blog-post-preview-text")).toHaveText(
+                BLOG_POST_TEXT,
+            );
 
             const castPicker = page.getByRole("combobox", {
                 name: "タグ付けするキャストを選択",
@@ -66,6 +92,12 @@ if (!taggedCast) {
             await expect(
                 page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
             ).toBeVisible();
+            await expect(
+                page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
+            ).toContainText(BLOG_POST_TEXT);
+            await page.getByTestId(`blog-post-image-${BLOG_POST_ID}-0`).click();
+            await expect(page.locator(".PhotoView-Portal")).toBeVisible();
+            await page.keyboard.press("Escape");
 
             await page.goto(`${GALLERY_URL}/casts/${taggedCast.enName}`);
             await page.getByRole("tab", { name: /BLOG/ }).click();

--- a/e2e/blog-post-flow.spec.ts
+++ b/e2e/blog-post-flow.spec.ts
@@ -66,9 +66,15 @@ if (!taggedCast) {
                     response.url().includes("/api/casts"),
                 ),
             ]);
+            await page
+                .getByTestId("gallery-destination-checkbox")
+                .locator("input")
+                .uncheck();
+            await page
+                .getByTestId("blog-destination-checkbox")
+                .locator("input")
+                .check();
             await page.getByTestId("tweet-id-input").fill(BLOG_POST_ID);
-            await page.getByTestId("gallery-destination-checkbox").uncheck();
-            await page.getByTestId("blog-destination-checkbox").check();
             await expect(page.getByTestId("blog-post-preview")).toBeVisible();
             await expect(page.getByTestId("blog-post-preview-text")).toHaveText(
                 BLOG_POST_TEXT,
@@ -132,12 +138,12 @@ if (!taggedCast) {
                     response.url().includes("/api/casts"),
                 ),
             ]);
-            const blogDestination = page.getByTestId(
-                "blog-destination-checkbox",
-            );
-            const shiftDestination = page.getByTestId(
-                "shift-destination-checkbox",
-            );
+            const blogDestination = page
+                .getByTestId("blog-destination-checkbox")
+                .locator("input");
+            const shiftDestination = page
+                .getByTestId("shift-destination-checkbox")
+                .locator("input");
 
             await blogDestination.check();
             await expect(blogDestination).toBeChecked();

--- a/e2e/blog-post-flow.spec.ts
+++ b/e2e/blog-post-flow.spec.ts
@@ -4,7 +4,15 @@ import { getTestCasts } from "./lib/test-data";
 const ADMIN_URL = "http://localhost:3001";
 const GALLERY_URL = "http://localhost:3000";
 const BLOG_POST_ID = "11647688710085046272";
-const BLOG_POST_TEXT = "登録前に確認できるBLOGポスト本文";
+const BLOG_POST_TEXT = [
+    "登録前に確認できるBLOGポスト本文 1",
+    "登録前に確認できるBLOGポスト本文 2",
+    "登録前に確認できるBLOGポスト本文 3",
+    "登録前に確認できるBLOGポスト本文 4",
+    "登録前に確認できるBLOGポスト本文 5",
+    "登録前に確認できるBLOGポスト本文 6",
+    "登録前に確認できるBLOGポスト本文 7",
+].join("\n");
 
 const casts = getTestCasts();
 const taggedCast = casts[0] ?? null;
@@ -95,6 +103,12 @@ if (!taggedCast) {
             await expect(
                 page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
             ).toContainText(BLOG_POST_TEXT);
+            const expandButton = page.getByTestId(
+                `blog-post-expand-${BLOG_POST_ID}`,
+            );
+            await expect(expandButton).toHaveText("続きを見る");
+            await expandButton.click();
+            await expect(expandButton).toHaveText("閉じる");
             await page.getByTestId(`blog-post-image-${BLOG_POST_ID}-0`).click();
             await expect(page.locator(".PhotoView-Portal")).toBeVisible();
             await page.keyboard.press("Escape");

--- a/e2e/blog-post-flow.spec.ts
+++ b/e2e/blog-post-flow.spec.ts
@@ -73,5 +73,53 @@ if (!taggedCast) {
                 page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
             ).toBeVisible();
         });
+
+        test("BLOGとシフトは同時に選択できない", async ({ page }) => {
+            await Promise.all([
+                page.goto(ADMIN_URL),
+                page.waitForResponse((response) =>
+                    response.url().includes("/api/casts"),
+                ),
+            ]);
+            const blogDestination = page.getByTestId(
+                "blog-destination-checkbox",
+            );
+            const shiftDestination = page.getByTestId(
+                "shift-destination-checkbox",
+            );
+
+            await blogDestination.check();
+            await expect(blogDestination).toBeChecked();
+            await expect(shiftDestination).not.toBeChecked();
+
+            await shiftDestination.check();
+            await expect(shiftDestination).toBeChecked();
+            await expect(blogDestination).not.toBeChecked();
+
+            await blogDestination.check();
+            await expect(blogDestination).toBeChecked();
+            await expect(shiftDestination).not.toBeChecked();
+        });
+
+        test("BLOGとシフトの同時登録リクエストを拒否する", async ({
+            page,
+        }) => {
+            const response = await page.request.post(
+                `${ADMIN_URL}/api/post-registrations`,
+                {
+                    data: {
+                        postId: BLOG_POST_ID,
+                        destinations: { gallery: false, blog: true, shift: true },
+                        taggedCastIds: [taggedCast.id],
+                        shiftCastIds: [taggedCast.id],
+                    },
+                },
+            );
+
+            expect(response.status()).toBe(400);
+            expect(await response.json()).toEqual({
+                error: "BLOGとシフトを同時には登録できません",
+            });
+        });
     });
 }

--- a/e2e/blog-post-flow.spec.ts
+++ b/e2e/blog-post-flow.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import { getTestCasts } from "./lib/test-data";
+
+const ADMIN_URL = "http://localhost:3001";
+const GALLERY_URL = "http://localhost:3000";
+const BLOG_POST_ID = "11647688710085046272";
+
+const casts = getTestCasts();
+const taggedCast = casts[0] ?? null;
+
+if (!taggedCast) {
+    test.describe.skip("BLOGポスト登録（キャストデータなし）", () => {
+        test("スキップ", () => {});
+    });
+} else {
+    test.describe("BLOGポスト登録と公開表示", () => {
+        test.beforeEach(async ({ page }) => {
+            await page.request.post(`${ADMIN_URL}/api/auth/e2e-login`);
+            await page.request.delete(`${ADMIN_URL}/api/posts/${BLOG_POST_ID}`);
+        });
+
+        test.afterEach(async ({ page }) => {
+            await page.request.delete(`${ADMIN_URL}/api/posts/${BLOG_POST_ID}`);
+        });
+
+        test("BLOGとして登録したポストをギャラリーから分離し、キャスト詳細で表示する", async ({
+            page,
+        }) => {
+            await Promise.all([
+                page.goto(ADMIN_URL),
+                page.waitForResponse((response) =>
+                    response.url().includes("/api/casts"),
+                ),
+            ]);
+            await page.getByTestId("tweet-id-input").fill(BLOG_POST_ID);
+            await page.getByTestId("gallery-destination-checkbox").uncheck();
+            await page.getByTestId("blog-destination-checkbox").check();
+            await expect(page.getByTestId("blog-post-preview")).toBeVisible();
+
+            const castPicker = page.getByRole("combobox", {
+                name: "タグ付けするキャストを選択",
+            });
+            await castPicker.fill(taggedCast.name);
+            await page.getByRole("option", { name: taggedCast.name }).click();
+
+            const saveResponse = page.waitForResponse(
+                (response) =>
+                    response.url() === `${ADMIN_URL}/api/post-registrations` &&
+                    response.request().method() === "POST",
+            );
+            await page.getByTestId("tweet-register-button").click();
+            expect((await saveResponse).status()).toBe(201);
+
+            const postResponse = await page.request.get(
+                `${ADMIN_URL}/api/posts/${BLOG_POST_ID}`,
+            );
+            expect(postResponse.ok()).toBeTruthy();
+            const post = await postResponse.json();
+            expect(post.contentType).toBe("blog");
+            expect(post.showInGallery).toBe(true);
+            expect(post.castTags.map((tag: { castid: number }) => tag.castid)).toEqual([
+                taggedCast.id,
+            ]);
+
+            await page.goto(`${GALLERY_URL}/blog`);
+            await expect(
+                page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
+            ).toBeVisible();
+
+            await page.goto(`${GALLERY_URL}/casts/${taggedCast.enName}`);
+            await page.getByRole("tab", { name: /BLOG/ }).click();
+            await expect(
+                page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
+            ).toBeVisible();
+        });
+    });
+}

--- a/packages/dao/src/entities/Post.ts
+++ b/packages/dao/src/entities/Post.ts
@@ -1,5 +1,5 @@
 import { Column, Entity, OneToMany, JoinTable, PrimaryColumn, ManyToMany } from "typeorm";
-import { ShiftSourceStatus } from "@iba-cast-gallery/types";
+import { PostContentType, ShiftSourceStatus } from "@iba-cast-gallery/types";
 import { Cast } from "./Cast";
 import { PostCastTag } from "./PostCastTag";
 import { Favorite } from "./Favorite";
@@ -28,6 +28,15 @@ export class Post {
     default: true,
   })
   showInGallery: boolean;
+
+  @Column({
+    name: "content_type",
+    type: "enum",
+    enum: PostContentType,
+    enumName: "posts_content_type_enum",
+    default: PostContentType.GALLERY,
+  })
+  contentType: PostContentType;
 
   @Column({
     name: "shift_source",

--- a/packages/dao/src/migrations/1785542400000-addBlogPostType.ts
+++ b/packages/dao/src/migrations/1785542400000-addBlogPostType.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * 画像ギャラリー用ポストと IBAだいありぃ BLOG ポストを区別する。
+ * 指定された BLOG ポストをルチルのタグ付きで初期登録する。
+ */
+export class AddBlogPostType1785542400000 implements MigrationInterface {
+    private readonly schema = process.env.DB_SCHEMA ?? "public";
+    private readonly samplePostId = "1978264565742973070";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TYPE "${this.schema}"."posts_content_type_enum" AS ENUM ('gallery', 'blog')
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "${this.schema}"."posts"
+            ADD COLUMN "content_type" "${this.schema}"."posts_content_type_enum"
+            NOT NULL DEFAULT 'gallery'
+        `);
+        await queryRunner.query(`
+            CREATE INDEX "IDX_posts_content_type_posted_at"
+            ON "${this.schema}"."posts" ("content_type", "posted_at" DESC)
+        `);
+
+        await queryRunner.query(
+            `
+                INSERT INTO "${this.schema}"."posts"
+                    ("id", "posted_at", "is_deleted", "show_in_gallery", "content_type")
+                VALUES ($1, $2, false, true, 'blog')
+                ON CONFLICT ("id") DO UPDATE
+                SET "posted_at" = EXCLUDED."posted_at",
+                    "is_deleted" = false,
+                    "show_in_gallery" = true,
+                    "content_type" = 'blog'
+            `,
+            [this.samplePostId, "2025-10-15T01:00:01.508Z"],
+        );
+        await queryRunner.query(
+            `
+                INSERT INTO "${this.schema}"."post_cast_tags"
+                    ("post_id", "cast_id", "order")
+                VALUES ($1, 21, 1)
+                ON CONFLICT ("post_id", "cast_id") DO NOTHING
+            `,
+            [this.samplePostId],
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DELETE FROM "${this.schema}"."posts" WHERE "id" = $1 AND "content_type" = 'blog'`,
+            [this.samplePostId],
+        );
+        await queryRunner.query(`DROP INDEX "${this.schema}"."IDX_posts_content_type_posted_at"`);
+        await queryRunner.query(`ALTER TABLE "${this.schema}"."posts" DROP COLUMN "content_type"`);
+        await queryRunner.query(`DROP TYPE "${this.schema}"."posts_content_type_enum"`);
+    }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export { CastType } from "./cast";
 export type { CastDto } from "./cast";
+export { PostContentType } from "./post";
 export type { PostDto, PostWithCastsDto } from "./post";
 export type { PostRegistrationRequest, PostRegistrationResult, ShiftRegistrationInput } from "./postRegistration";
 export { ShiftSlot, ShiftSourceStatus } from "./shift";

--- a/packages/types/src/post.ts
+++ b/packages/types/src/post.ts
@@ -1,8 +1,14 @@
 import {CastDto} from "./cast";
 
+export enum PostContentType {
+    GALLERY = "gallery",
+    BLOG = "blog",
+}
+
 export interface PostDto {
     id: string;
     postedAt: string;
+    contentType: PostContentType;
     taggedCasts: {
         order:number;
         castId: number;
@@ -12,6 +18,7 @@ export interface PostDto {
 export interface PostWithCastsDto {
     id: string;
     postedAt: string;
+    contentType: PostContentType;
     taggedCasts: {
         order: number;
         cast: CastDto;

--- a/packages/types/src/postRegistration.ts
+++ b/packages/types/src/postRegistration.ts
@@ -11,6 +11,7 @@ export interface PostRegistrationRequest {
     isDeleted?: boolean;
     destinations: {
         gallery: boolean;
+        blog?: boolean;
         shift: boolean;
     };
     taggedCastIds: number[];


### PR DESCRIPTION
## 概要

IBAだいありぃのBLOGポストを、画像ギャラリーとは別カテゴリとして登録・表示できるようにします。

- `posts.content_type` に `gallery` / `blog` を追加
- 登録画面に「BLOGに登録」を追加し、キャストタグ付けに対応
- `/blog` のBLOG一覧とナビゲーションを追加
- キャスト詳細を「画像ポスト」「BLOG」タブに分離
- 指定ポスト `1978264565742973070` をBLOG・ルチルタグとしてマイグレーションで初期登録
- BLOG登録から公開表示までを確認するE2Eテストを追加

## 検証

- `tsc --noEmit`（DAO / 公開アプリ / 管理アプリ）
- 変更箇所のESLint
- DBスキーマのユニットテスト
- 新規Playwrightテストの検出

DockerがこのWSLから利用できないため、E2E実行はPreview/CIで確認予定です。