### PR TITLE
feat: ポスト一覧を段階的に表示する

### DIFF
--- a/app/iba-cast-gallery/src/app/blog/page.tsx
+++ b/app/iba-cast-gallery/src/app/blog/page.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from "@mui/material";
 import { getActiveCasts } from "services/castService";
 import { getExistsBlogPosts } from "services/postService";
 import type { CastDto, PostWithCastsDto } from "@iba-cast-gallery/types";
-import BlogPosts from "components/BlogPosts";
+import BlogPostFilter from "components/BlogPostFilter";
 
 export const dynamic = "force-dynamic";
 
@@ -32,7 +32,7 @@ export default async function BlogPage() {
         IBAだいありぃで紹介されたキャストのBLOGポストです。
       </Typography>
       {joinedPosts.length > 0 ? (
-        <BlogPosts posts={joinedPosts} />
+        <BlogPostFilter casts={casts} posts={joinedPosts} />
       ) : (
         <Typography color="text.secondary">BLOGポストはまだありません。</Typography>
       )}

--- a/app/iba-cast-gallery/src/components/BlogPostFilter.tsx
+++ b/app/iba-cast-gallery/src/components/BlogPostFilter.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { useMemo, useState } from "react";
+import type { CastDto, PostWithCastsDto } from "@iba-cast-gallery/types";
+import BlogPosts from "components/BlogPosts";
+import CastSelect from "components/CastSelect";
+
+/** IBAだいありぃ BLOG をキャストタグで絞り込んで表示する。 */
+export default function BlogPostFilter({
+  posts,
+  casts,
+}: {
+  posts: PostWithCastsDto[];
+  casts: CastDto[];
+}) {
+  const [selectedCast, setSelectedCast] = useState<CastDto | null>(null);
+  const displayPosts = useMemo(
+    () =>
+      selectedCast
+        ? posts.filter((post) =>
+            post.taggedCasts.some(
+              ({ cast }) => cast.id === selectedCast.id,
+            ),
+          )
+        : posts,
+    [posts, selectedCast],
+  );
+
+  return (
+    <>
+      <Box sx={{ mb: 3 }}>
+        <CastSelect
+          casts={casts}
+          selectedCast={selectedCast}
+          setSelectedCast={setSelectedCast}
+        />
+      </Box>
+      {displayPosts.length > 0 ? (
+        <BlogPosts posts={displayPosts} />
+      ) : (
+        <Typography color="text.secondary">
+          このキャストのBLOGポストはまだありません。
+        </Typography>
+      )}
+    </>
+  );
+}

--- a/app/iba-cast-gallery/src/components/BlogPosts.tsx
+++ b/app/iba-cast-gallery/src/components/BlogPosts.tsx
@@ -1,6 +1,8 @@
-import { Grid } from "@mui/material";
+"use client";
+
 import type { PostWithCastsDto } from "@iba-cast-gallery/types";
 import BlogPostCard from "components/BlogPostCard";
+import IncrementalPostGrid from "components/IncrementalPostGrid";
 
 export default function BlogPosts({
   posts,
@@ -8,12 +10,11 @@ export default function BlogPosts({
   posts: PostWithCastsDto[];
 }) {
   return (
-    <Grid container spacing={2} className="w-full">
-      {posts.map((post) => (
-        <Grid key={post.id} size={{ xs: 12, md: 6, lg: 4 }}>
-          <BlogPostCard post={post} />
-        </Grid>
-      ))}
-    </Grid>
+    <IncrementalPostGrid
+      items={posts}
+      getItemKey={(post) => post.id}
+      renderItem={(post) => <BlogPostCard post={post} />}
+      itemSize={{ xs: 12, md: 6, lg: 4 }}
+    />
   );
 }

--- a/app/iba-cast-gallery/src/components/IncrementalPostGrid.tsx
+++ b/app/iba-cast-gallery/src/components/IncrementalPostGrid.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Box, Button, Grid } from "@mui/material";
+import {
+  type ComponentProps,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+const INITIAL_POST_COUNT = 9;
+const POST_BATCH_SIZE = 6;
+
+type IncrementalPostGridProps<T> = {
+  items: T[];
+  getItemKey: (item: T) => string;
+  renderItem: (item: T) => ReactNode;
+  itemSize: ComponentProps<typeof Grid>["size"];
+};
+
+/**
+ * 一覧のカードを段階的にマウントする。
+ * 未表示のポストは Tweet API や画像のリクエストを開始しないため、初期表示の通信量を抑えられる。
+ */
+export default function IncrementalPostGrid<T>({
+  items,
+  getItemKey,
+  renderItem,
+  itemSize,
+}: IncrementalPostGridProps<T>) {
+  const [visibleCount, setVisibleCount] = useState(() =>
+    Math.min(INITIAL_POST_COUNT, items.length),
+  );
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+  const hasMore = visibleCount < items.length;
+
+  useEffect(() => {
+    setVisibleCount(Math.min(INITIAL_POST_COUNT, items.length));
+  }, [items]);
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((current) =>
+      Math.min(current + POST_BATCH_SIZE, items.length),
+    );
+  }, [items.length]);
+
+  useEffect(() => {
+    if (!hasMore || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const target = loadMoreRef.current;
+    if (!target) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin: "400px" },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [hasMore, loadMore]);
+
+  return (
+    <>
+      <Grid container spacing={2} className="w-full">
+        {items.slice(0, visibleCount).map((item) => (
+          <Grid key={getItemKey(item)} size={itemSize}>
+            {renderItem(item)}
+          </Grid>
+        ))}
+      </Grid>
+      {hasMore && (
+        <Box
+          ref={loadMoreRef}
+          data-testid="post-load-more"
+          sx={{ display: "flex", justifyContent: "center", py: 3 }}
+        >
+          <Button onClick={loadMore} variant="outlined">
+            さらに表示
+          </Button>
+        </Box>
+      )}
+    </>
+  );
+}

--- a/app/iba-cast-gallery/src/components/Tweets.tsx
+++ b/app/iba-cast-gallery/src/components/Tweets.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import TweetCard from "components/TweetCard";
-import { Grid } from "@mui/material";
-import { PostWithCastsDto } from "@iba-cast-gallery/types";
+import IncrementalPostGrid from "components/IncrementalPostGrid";
+import type { PostWithCastsDto } from "@iba-cast-gallery/types";
 
 export default function Tweets({
   joinedPosts,
@@ -8,12 +10,11 @@ export default function Tweets({
   joinedPosts: PostWithCastsDto[];
 }) {
   return (
-    <Grid container spacing={2} className="w-full">
-      {joinedPosts.map((tweet) => (
-        <Grid key={tweet.id} size={{ xs: 12, md: 6, lg: 4, xl: 3 }}>
-          <TweetCard tweet={tweet} />
-        </Grid>
-      ))}
-    </Grid>
+    <IncrementalPostGrid
+      items={joinedPosts}
+      getItemKey={(tweet) => tweet.id}
+      renderItem={(tweet) => <TweetCard tweet={tweet} />}
+      itemSize={{ xs: 12, md: 6, lg: 4, xl: 3 }}
+    />
   );
 }

--- a/e2e/blog-post-flow.spec.ts
+++ b/e2e/blog-post-flow.spec.ts
@@ -109,6 +109,14 @@ if (!taggedCast) {
             await expect(
                 page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
             ).toBeVisible();
+            const blogCastFilter = page.getByRole("combobox", {
+                name: "キャストで絞り込み",
+            });
+            await blogCastFilter.fill(taggedCast.name);
+            await page.getByRole("option", { name: taggedCast.name }).click();
+            await expect(
+                page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
+            ).toBeVisible();
             await expect(
                 page.getByTestId(`blog-post-card-${BLOG_POST_ID}`),
             ).toContainText(BLOG_POST_TEXT);

--- a/e2e/tweet-flow.spec.ts
+++ b/e2e/tweet-flow.spec.ts
@@ -82,10 +82,49 @@ test.describe('Tweet Tagger and Gallery Flow', () => {
         await expect(tweetContainer.getByTestId('cast-tag-3')).toHaveText('ベリル');
         await expect(tweetContainer.getByTestId('cast-tag-4')).toHaveText('シトリン');
 
+        // 遅延表示の2バッチ目に対象投稿を置く。登録フローの検証を維持しつつ、
+        // 全件をマウントせず「さらに表示」で到達できることを確認する。
+        const postsResponse = await page.request.get('http://localhost:3001/api/posts');
+        expect(postsResponse.ok()).toBeTruthy();
+        const posts = await postsResponse.json();
+        const currentPost = posts.find((post: { id: string }) => post.id === tweetId);
+        const visibleGalleryPosts = posts
+            .filter((post: {
+                id: string;
+                isDeleted: boolean;
+                showInGallery: boolean;
+                contentType: string;
+            }) =>
+                post.id !== tweetId &&
+                !post.isDeleted &&
+                post.showInGallery &&
+                post.contentType === 'gallery'
+            )
+            .sort((a: { postedAt: string }, b: { postedAt: string }) =>
+                new Date(b.postedAt).getTime() - new Date(a.postedAt).getTime()
+            );
+        const lastInitialPost = visibleGalleryPosts[8];
+        expect(currentPost).toBeDefined();
+        expect(lastInitialPost).toBeDefined();
+
+        const updateResponse = await page.request.post('http://localhost:3001/api/posts', {
+            data: {
+                post: {
+                    ...currentPost,
+                    postedAt: new Date(
+                        new Date(lastInitialPost.postedAt).getTime() - 1
+                    ).toISOString(),
+                },
+            },
+        });
+        expect(updateResponse.status()).toBe(201);
+
 
         // ギャラリー側でも表示されていることを検証する
         await page.goto('http://localhost:3000');
         const tweetContainerInGallery = page.getByTestId(`tweet-container-${tweetId}`);
+        await expect(tweetContainerInGallery).not.toBeAttached();
+        await page.getByTestId('post-load-more').click();
         await expect(tweetContainerInGallery).toBeVisible();
 
         await expect(tweetContainerInGallery.getByTestId('cast-tag-1')).toHaveText('メノウ');


### PR DESCRIPTION
## 変更内容

- BLOG一覧に「キャストで絞り込み」を追加
- ギャラリー、BLOG、お気に入り、キャスト詳細の各ポスト一覧を段階的にレンダリング
  - 初期表示は9件
  - スクロール付近で6件ずつ追加
  - JavaScript無効化・IntersectionObserver非対応時にも使える「さらに表示」ボタンを用意
- 未表示のカードをマウントしないため、Tweet情報・画像リクエストの初期集中を抑制

## 検証

- `turbo build --force`（8タスク成功）
- BLOGポスト登録・表示のE2E（3件成功、Node.js 20 / production構成）