### PR TITLE
perf: PWA共有の起動画面を短縮する

### DIFF
--- a/app/tweet-tagger/src/app/api/share-drafts/[postId]/route.ts
+++ b/app/tweet-tagger/src/app/api/share-drafts/[postId]/route.ts
@@ -1,0 +1,41 @@
+import { auth } from "auth";
+import { NextResponse } from "next/server";
+import { ensureDraftPost } from "services/postService";
+import { extractPostId } from "utils/postId";
+
+/**
+ * 共有受付画面から、Xポストを非公開ドラフトとして保存する。
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ postId: string }> },
+) {
+  const rawPostId = (await params).postId;
+  const postId = extractPostId(rawPostId);
+  if (postId === null || postId !== rawPostId) {
+    return NextResponse.json(
+      { error: "共有された内容からXのポストURLを読み取れませんでした" },
+      { status: 400 },
+    );
+  }
+
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (session.user.email !== process.env.ADMIN_EMAIL) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    await ensureDraftPost(postId);
+    return NextResponse.json({ postId }, { status: 201 });
+  } catch (error) {
+    console.error("Error saving shared post as draft:", error);
+    return NextResponse.json(
+      { error: "Failed to save shared post as draft" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/tweet-tagger/src/app/share/prepare/SharePreparation.tsx
+++ b/app/tweet-tagger/src/app/share/prepare/SharePreparation.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+import SharePreparationStatus from "./SharePreparationStatus";
+
+export default function SharePreparation() {
+  const router = useRouter();
+  const postId = useSearchParams().get("id");
+  const processingPostIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (postId === null) {
+      router.replace("/?shareError=invalid");
+      return;
+    }
+    if (processingPostIdRef.current === postId) {
+      return;
+    }
+    processingPostIdRef.current = postId;
+
+    const saveDraft = async () => {
+      try {
+        const response = await fetch(
+          `/api/share-drafts/${encodeURIComponent(postId)}`,
+          { method: "POST" },
+        );
+
+        if (response.status === 401) {
+          const callbackUrl = new URL("/share/prepare", window.location.origin);
+          callbackUrl.searchParams.set("id", postId);
+          window.location.assign(
+            `/api/auth/signin?callbackUrl=${encodeURIComponent(
+              callbackUrl.toString(),
+            )}`,
+          );
+          return;
+        }
+
+        if (response.status === 403) {
+          router.replace("/");
+          return;
+        }
+
+        if (!response.ok) {
+          throw new Error("Failed to save shared post as draft");
+        }
+
+        router.replace(`/posts/${postId}/edit?shared=1`);
+      } catch (error) {
+        console.error("Error preparing shared post:", error);
+        router.replace("/?shareError=failed");
+      }
+    };
+
+    void saveDraft();
+  }, [postId, router]);
+
+  return <SharePreparationStatus />;
+}

--- a/app/tweet-tagger/src/app/share/prepare/SharePreparationStatus.tsx
+++ b/app/tweet-tagger/src/app/share/prepare/SharePreparationStatus.tsx
@@ -1,0 +1,16 @@
+export default function SharePreparationStatus() {
+  return (
+    <div
+      aria-live="polite"
+      className="flex flex-col items-center gap-4 py-16"
+      role="status"
+    >
+      <span
+        aria-label="共有ポストを準備中"
+        className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600"
+        role="progressbar"
+      />
+      <p>共有ポストを開いています…</p>
+    </div>
+  );
+}

--- a/app/tweet-tagger/src/app/share/prepare/page.tsx
+++ b/app/tweet-tagger/src/app/share/prepare/page.tsx
@@ -1,0 +1,11 @@
+import SharePreparation from "./SharePreparation";
+import SharePreparationStatus from "./SharePreparationStatus";
+import { Suspense } from "react";
+
+export default function SharePreparationPage() {
+  return (
+    <Suspense fallback={<SharePreparationStatus />}>
+      <SharePreparation />
+    </Suspense>
+  );
+}

--- a/app/tweet-tagger/src/app/share/route.ts
+++ b/app/tweet-tagger/src/app/share/route.ts
@@ -1,6 +1,4 @@
-import { auth } from "auth";
 import { NextResponse } from "next/server";
-import { ensureDraftPost } from "services/postService";
 import { extractPostId } from "utils/postId";
 
 const SEE_OTHER = 303;
@@ -11,36 +9,10 @@ function redirectToHome(request: Request, error: "invalid" | "failed") {
   return NextResponse.redirect(url, SEE_OTHER);
 }
 
-function redirectToSignIn(request: Request, postId: string) {
-  const callbackUrl = new URL("/share", request.url);
-  callbackUrl.searchParams.set("id", postId);
-
-  const signInUrl = new URL("/api/auth/signin", request.url);
-  signInUrl.searchParams.set("callbackUrl", callbackUrl.toString());
-  return NextResponse.redirect(signInUrl, SEE_OTHER);
-}
-
-async function saveDraftAndRedirect(request: Request, postId: string) {
-  const session = await auth();
-
-  if (!session?.user) {
-    return redirectToSignIn(request, postId);
-  }
-
-  if (session.user.email !== process.env.ADMIN_EMAIL) {
-    return NextResponse.redirect(new URL("/", request.url), SEE_OTHER);
-  }
-
-  try {
-    await ensureDraftPost(postId);
-    return NextResponse.redirect(
-      new URL(`/posts/${postId}/edit?shared=1`, request.url),
-      SEE_OTHER,
-    );
-  } catch (error) {
-    console.error("Error saving shared post as draft:", error);
-    return redirectToHome(request, "failed");
-  }
+function redirectToPreparation(request: Request, postId: string) {
+  const url = new URL("/share/prepare", request.url);
+  url.searchParams.set("id", postId);
+  return NextResponse.redirect(url, SEE_OTHER);
 }
 
 /**
@@ -58,18 +30,6 @@ export async function POST(request: Request) {
     return redirectToHome(request, "invalid");
   }
 
-  return saveDraftAndRedirect(request, postId);
-}
-
-/**
- * 共有時にログインが切れていた場合、ログイン後にドラフト保存を再開する。
- */
-export async function GET(request: Request) {
-  const postId = extractPostId(new URL(request.url).searchParams.get("id"));
-
-  if (postId === null) {
-    return redirectToHome(request, "invalid");
-  }
-
-  return saveDraftAndRedirect(request, postId);
+  // PWAの起動画面を早く閉じるため、認証・DB保存は受付画面を描画した後に行う。
+  return redirectToPreparation(request, postId);
 }

--- a/e2e/share-draft-flow.spec.ts
+++ b/e2e/share-draft-flow.spec.ts
@@ -30,7 +30,42 @@ test.describe("X共有からのドラフト保存", () => {
 
       expect(response.status()).toBe(303);
       expect(response.headers().location).toContain(
-        `/posts/${DRAFT_POST_ID}/edit?shared=1`,
+        `/share/prepare?id=${DRAFT_POST_ID}`,
+      );
+
+      // PWAの起動画面を早く閉じるため、共有POSTではDB保存を待たない。
+      const beforePreparationResponse = await page.request.get(
+        `${ADMIN_URL}/api/posts/${DRAFT_POST_ID}`,
+      );
+      expect(beforePreparationResponse.status()).toBe(404);
+
+      let markSaveRequestStarted!: () => void;
+      let resumeSaveRequest!: () => void;
+      const saveRequestStarted = new Promise<void>((resolve) => {
+        markSaveRequestStarted = resolve;
+      });
+      await page.route(
+        `${ADMIN_URL}/api/share-drafts/${DRAFT_POST_ID}`,
+        async (route) => {
+          markSaveRequestStarted();
+          await new Promise<void>((resolve) => {
+            resumeSaveRequest = resolve;
+          });
+          await route.continue();
+        },
+      );
+      const saveDraftResponse = page.waitForResponse(
+        (res) =>
+          res.url() === `${ADMIN_URL}/api/share-drafts/${DRAFT_POST_ID}` &&
+          res.request().method() === "POST",
+      );
+      await page.goto(`${ADMIN_URL}/share/prepare?id=${DRAFT_POST_ID}`);
+      await saveRequestStarted;
+      await expect(page.getByText("共有ポストを開いています…")).toBeVisible();
+      resumeSaveRequest();
+      expect((await saveDraftResponse).status()).toBe(201);
+      await expect(page).toHaveURL(
+        `${ADMIN_URL}/posts/${DRAFT_POST_ID}/edit?shared=1`,
       );
 
       const savedPostResponse = await page.request.get(
@@ -100,6 +135,14 @@ test.describe("X共有からのドラフト保存", () => {
         maxRedirects: 0,
       });
       expect(shareResponse.status()).toBe(303);
+
+      const saveDraftResponse = page.waitForResponse(
+        (res) =>
+          res.url() === `${ADMIN_URL}/api/share-drafts/${PUBLISHED_POST_ID}` &&
+          res.request().method() === "POST",
+      );
+      await page.goto(`${ADMIN_URL}/share/prepare?id=${PUBLISHED_POST_ID}`);
+      expect((await saveDraftResponse).status()).toBe(201);
 
       const savedPostResponse = await page.request.get(
         `${ADMIN_URL}/api/posts/${PUBLISHED_POST_ID}`,


### PR DESCRIPTION
## 変更内容

- PWA共有ターゲットのPOST処理を、URL抽出後すぐに軽量な受付画面へリダイレクトする構成へ変更
- 認証確認とドラフト保存を、受付画面の初回描画後に専用APIで実行
- 認証切れ時はログイン後に同じ共有処理を再開
- 公開済みポストを再共有しても公開状態を維持
- 受付画面を静的生成し、MUIに依存しない最小構成へ軽量化

## 狙い

従来は共有POST内で認証とDB保存を待ってから編集画面へ遷移していたため、AndroidのPWAスプラッシュが長く表示される構造でした。先に静的な受付画面を描画することで、OSのスプラッシュからアプリ画面へ早く切り替わるようにします。

## 検証

- Node.js 20でtweet-tagger本番ビルド成功
- `/share/prepare` が静的生成されることを確認
- 受付画面のFirst Load JS: 103 kB（編集画面は279 kB）
- 共有E2E 3件成功
  - 共有POST時点ではDB保存されない
  - 保存APIを停止中でも受付画面が先に表示される
  - 保存後に編集画面へ遷移する
  - 公開済み投稿の状態を維持する
- 全E2E 74件成功

## 実機確認

Android実機では、共有から「共有ポストを開いています…」へ切り替わるまでの体感時間を確認してください。Service Workerの追加はこのPRには含めていません。