### PR TITLE
管理画面のポスト一覧とシフト補完を改善

### DIFF
--- a/app/tweet-tagger/src/app/api/post-summaries/route.ts
+++ b/app/tweet-tagger/src/app/api/post-summaries/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { auth } from "auth";
+import { getPostManagementSummaries } from "services/postService";
+
+export async function GET() {
+    const session = await auth();
+    if (session?.user?.email !== process.env.ADMIN_EMAIL) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        const posts = await getPostManagementSummaries();
+        return NextResponse.json(posts, { status: 200 });
+    } catch (error) {
+        console.error("Error fetching post management summaries:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch post management summaries" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/tweet-tagger/src/app/api/posts/[postId]/route.ts
+++ b/app/tweet-tagger/src/app/api/posts/[postId]/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
-import { getPostById, deletePostById } from "services/postService";
+import {
+    deletePostById,
+    getPostById,
+    updatePostShiftRegistrationExclusion,
+} from "services/postService";
 import { auth } from "auth";
 
 /**
@@ -58,5 +62,56 @@ export async function DELETE(
     } catch (error) {
         console.error("Error deleting post:", error);
         return NextResponse.json({ error: "Failed to delete post" }, { status: 500 });
+    }
+}
+
+/**
+ * シフト登録候補からの除外状態を更新する。
+ */
+export async function PATCH(
+    request: Request,
+    { params }: { params: Promise<{ postId: string }> },
+) {
+    const session = await auth();
+    if (session?.user?.email !== process.env.ADMIN_EMAIL) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        const body: unknown = await request.json();
+        if (
+            typeof body !== "object" ||
+            body === null ||
+            !("excludeFromShiftRegistration" in body) ||
+            typeof body.excludeFromShiftRegistration !== "boolean"
+        ) {
+            return NextResponse.json(
+                { error: "excludeFromShiftRegistration must be a boolean" },
+                { status: 400 },
+            );
+        }
+
+        const postId = (await params).postId;
+        const updated = await updatePostShiftRegistrationExclusion(
+            postId,
+            body.excludeFromShiftRegistration,
+        );
+        if (!updated) {
+            return NextResponse.json(
+                { error: "ポストが存在しません" },
+                { status: 404 },
+            );
+        }
+
+        return NextResponse.json(
+            { postId, excludeFromShiftRegistration: body.excludeFromShiftRegistration },
+            { status: 200 },
+        );
+    } catch (error) {
+        console.error("Error updating post shift registration exclusion:", error);
+        return NextResponse.json(
+            { error: "Failed to update post shift registration exclusion" },
+            { status: 500 },
+        );
     }
 }

--- a/app/tweet-tagger/src/app/api/posts/shift-candidates/route.ts
+++ b/app/tweet-tagger/src/app/api/posts/shift-candidates/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { ShiftSlot } from "@iba-cast-gallery/types";
+import { auth } from "auth";
+import { getShiftPostCandidates } from "services/shiftService";
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * GET /api/posts/shift-candidates?date=2026-08-07&shift=evening
+ * 未登録シフトに利用できる近い時間帯の既存ポストを取得する。
+ */
+export async function GET(request: Request) {
+    const session = await auth();
+    if (session?.user?.email !== process.env.ADMIN_EMAIL) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const date = searchParams.get("date");
+    const shift = searchParams.get("shift") as ShiftSlot | null;
+    const parsedDate = date ? new Date(`${date}T00:00:00+09:00`) : null;
+
+    if (
+        !date ||
+        !DATE_PATTERN.test(date) ||
+        !parsedDate ||
+        Number.isNaN(parsedDate.getTime()) ||
+        !shift ||
+        !Object.values(ShiftSlot).includes(shift)
+    ) {
+        return NextResponse.json(
+            { error: "有効な date と shift は必須です" },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const candidates = await getShiftPostCandidates(date, shift);
+        return NextResponse.json(candidates, { status: 200 });
+    } catch (error) {
+        console.error("Error fetching shift post candidates:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch shift post candidates" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/tweet-tagger/src/app/client-component/ShiftList.tsx
+++ b/app/tweet-tagger/src/app/client-component/ShiftList.tsx
@@ -27,6 +27,9 @@ import {
 import { ShiftSlot, ShiftGroup } from "@iba-cast-gallery/types";
 import { Tweet } from "../../components/tweet/swr";
 import dayjs from "dayjs";
+import ShiftPostCandidateDialog, {
+    type MissingShiftTarget,
+} from "app/client-component/ShiftPostCandidateDialog";
 
 const SHIFT_LABELS: Record<ShiftSlot, string> = {
     [ShiftSlot.OPEN]: "オープン",
@@ -47,11 +50,17 @@ const ShiftList = ({
     onFillMissing,
 }: {
     refreshKey: number;
-    onFillMissing: (date: string, slot: ShiftSlot) => void;
+    onFillMissing: (
+        date: string,
+        slot: ShiftSlot,
+        sourcePostId: string | null,
+    ) => void;
 }) => {
     const [groups, setGroups] = useState<ShiftGroup[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [previewGroup, setPreviewGroup] = useState<ShiftGroup | null>(null);
+    const [missingShiftTarget, setMissingShiftTarget] =
+        useState<MissingShiftTarget | null>(null);
     const [coverageFrom, setCoverageFrom] = useState(
         dayjs().subtract(13, "day").format("YYYY-MM-DD"),
     );
@@ -129,6 +138,18 @@ const ShiftList = ({
         (count, day) => count + day.slots.length,
         0,
     );
+
+    const selectMissingShiftSource = (sourcePostId: string | null) => {
+        if (!missingShiftTarget) {
+            return;
+        }
+        onFillMissing(
+            missingShiftTarget.date,
+            missingShiftTarget.slot,
+            sourcePostId,
+        );
+        setMissingShiftTarget(null);
+    };
 
     // ツイートURL → ID 変換
     useEffect(() => {
@@ -258,7 +279,13 @@ const ShiftList = ({
                                                 size="small"
                                                 variant="outlined"
                                                 color="warning"
-                                                onClick={() => onFillMissing(day.date, slot)}
+                                                onClick={() =>
+                                                    setMissingShiftTarget({
+                                                        date: day.date,
+                                                        dayOfWeek: day.dayOfWeek,
+                                                        slot,
+                                                    })
+                                                }
                                                 data-testid={`shift-missing-${day.date}-${slot}`}
                                             >
                                                 {`${SHIFT_LABELS[slot]}を入力`}
@@ -322,6 +349,12 @@ const ShiftList = ({
                     </Table>
                 </TableContainer>
             )}
+
+            <ShiftPostCandidateDialog
+                target={missingShiftTarget}
+                onClose={() => setMissingShiftTarget(null)}
+                onSelect={selectMissingShiftSource}
+            />
 
             {/* ソースプレビューダイアログ */}
             <Dialog

--- a/app/tweet-tagger/src/app/client-component/ShiftList.tsx
+++ b/app/tweet-tagger/src/app/client-component/ShiftList.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
     Alert,
+    Box,
     Button,
+    Chip,
     CircularProgress,
     Dialog,
     DialogContent,
@@ -24,6 +26,7 @@ import {
 } from "@mui/material";
 import { ShiftSlot, ShiftGroup } from "@iba-cast-gallery/types";
 import { Tweet } from "../../components/tweet/swr";
+import dayjs from "dayjs";
 
 const SHIFT_LABELS: Record<ShiftSlot, string> = {
     [ShiftSlot.OPEN]: "オープン",
@@ -31,10 +34,28 @@ const SHIFT_LABELS: Record<ShiftSlot, string> = {
     [ShiftSlot.NIGHT]: "夜",
 };
 
-const ShiftList = ({ refreshKey }: { refreshKey: number }) => {
+const EXPECTED_SHIFT_SLOTS = [
+    ShiftSlot.OPEN,
+    ShiftSlot.EVENING,
+    ShiftSlot.NIGHT,
+];
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+const MAX_COVERAGE_DAYS = 366;
+
+const ShiftList = ({
+    refreshKey,
+    onFillMissing,
+}: {
+    refreshKey: number;
+    onFillMissing: (date: string, slot: ShiftSlot) => void;
+}) => {
     const [groups, setGroups] = useState<ShiftGroup[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [previewGroup, setPreviewGroup] = useState<ShiftGroup | null>(null);
+    const [coverageFrom, setCoverageFrom] = useState(
+        dayjs().subtract(13, "day").format("YYYY-MM-DD"),
+    );
+    const [coverageTo, setCoverageTo] = useState(dayjs().format("YYYY-MM-DD"));
 
     // ソース追加ダイアログ用の状態
     const [addSourceTarget, setAddSourceTarget] = useState<ShiftGroup | null>(null);
@@ -51,6 +72,63 @@ const ShiftList = ({ refreshKey }: { refreshKey: number }) => {
             .catch(console.error)
             .finally(() => setIsLoading(false));
     }, [refreshKey]);
+
+    const coverageError = useMemo(() => {
+        const from = dayjs(coverageFrom);
+        const to = dayjs(coverageTo);
+        if (!from.isValid() || !to.isValid()) {
+            return "確認期間を入力してください";
+        }
+        if (from.isAfter(to, "day")) {
+            return "開始日は終了日以前にしてください";
+        }
+        if (to.diff(from, "day") >= MAX_COVERAGE_DAYS) {
+            return `確認期間は${MAX_COVERAGE_DAYS}日以内にしてください`;
+        }
+        return null;
+    }, [coverageFrom, coverageTo]);
+
+    const missingShiftDays = useMemo(() => {
+        if (coverageError) {
+            return [];
+        }
+
+        const registeredSlots = new Set(
+            groups.map((group) => `${group.date}__${group.shift}`),
+        );
+        const missing: {
+            date: string;
+            dayOfWeek: string;
+            slots: ShiftSlot[];
+        }[] = [];
+
+        let targetDate = dayjs(coverageFrom).startOf("day");
+        const endDate = dayjs(coverageTo).startOf("day");
+        while (!targetDate.isAfter(endDate, "day")) {
+            // 水曜（day() === 3）は定休日として登録対象から除外する。
+            if (targetDate.day() !== 3) {
+                const date = targetDate.format("YYYY-MM-DD");
+                const slots = EXPECTED_SHIFT_SLOTS.filter(
+                    (slot) => !registeredSlots.has(`${date}__${slot}`),
+                );
+                if (slots.length > 0) {
+                    missing.push({
+                        date,
+                        dayOfWeek: DAY_LABELS[targetDate.day()],
+                        slots,
+                    });
+                }
+            }
+            targetDate = targetDate.add(1, "day");
+        }
+
+        return missing.toReversed();
+    }, [coverageError, coverageFrom, coverageTo, groups]);
+
+    const missingSlotCount = missingShiftDays.reduce(
+        (count, day) => count + day.slots.length,
+        0,
+    );
 
     // ツイートURL → ID 変換
     useEffect(() => {
@@ -102,18 +180,105 @@ const ShiftList = ({ refreshKey }: { refreshKey: number }) => {
         return <CircularProgress size={24} />;
     }
 
-    if (groups.length === 0) {
-        return (
-            <Typography variant="body2" color="text.secondary">
-                登録済みシフトはありません
-            </Typography>
-        );
-    }
-
     return (
-        <>
-            <TableContainer component={Paper} data-testid="shift-list">
-                <Table size="small">
+        <Stack spacing={3}>
+            <Paper variant="outlined" sx={{ p: 2 }} data-testid="shift-coverage-panel">
+                <Stack spacing={2}>
+                    <Box>
+                        <Stack
+                            direction={{ xs: "column", sm: "row" }}
+                            spacing={1}
+                            alignItems={{ xs: "flex-start", sm: "center" }}
+                        >
+                            <Typography variant="subtitle1" fontWeight="bold">
+                                シフト入力漏れチェック
+                            </Typography>
+                            <Chip
+                                label={coverageError ? "期間を確認" : `${missingSlotCount}枠 未登録`}
+                                color={coverageError ? "error" : missingSlotCount > 0 ? "warning" : "success"}
+                                size="small"
+                            />
+                        </Stack>
+                        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                            水曜を定休日として除外し、各日のオープン・夕方・夜を確認します。
+                        </Typography>
+                    </Box>
+
+                    <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                        <TextField
+                            label="開始日"
+                            type="date"
+                            size="small"
+                            value={coverageFrom}
+                            onChange={(event) => setCoverageFrom(event.target.value)}
+                            slotProps={{
+                                inputLabel: { shrink: true },
+                                htmlInput: { "data-testid": "shift-coverage-from" },
+                            }}
+                        />
+                        <TextField
+                            label="終了日"
+                            type="date"
+                            size="small"
+                            value={coverageTo}
+                            onChange={(event) => setCoverageTo(event.target.value)}
+                            slotProps={{
+                                inputLabel: { shrink: true },
+                                htmlInput: { "data-testid": "shift-coverage-to" },
+                            }}
+                        />
+                    </Stack>
+
+                    {coverageError ? <Alert severity="error">{coverageError}</Alert> : null}
+                    {!coverageError && missingShiftDays.length === 0 ? (
+                        <Alert severity="success">この期間は3枠すべて登録済みです</Alert>
+                    ) : null}
+                    {!coverageError && missingShiftDays.length > 0 ? (
+                        <Stack
+                            spacing={1}
+                            sx={{ maxHeight: 360, overflowY: "auto", pr: 0.5 }}
+                            data-testid="shift-missing-list"
+                        >
+                            {missingShiftDays.map((day) => (
+                                <Stack
+                                    key={day.date}
+                                    direction={{ xs: "column", sm: "row" }}
+                                    spacing={1}
+                                    alignItems={{ xs: "stretch", sm: "center" }}
+                                    justifyContent="space-between"
+                                    sx={{ borderBottom: 1, borderColor: "divider", pb: 1 }}
+                                >
+                                    <Typography variant="body2" sx={{ minWidth: 130 }}>
+                                        {`${day.date} (${day.dayOfWeek})`}
+                                    </Typography>
+                                    <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                                        {day.slots.map((slot) => (
+                                            <Button
+                                                key={slot}
+                                                size="small"
+                                                variant="outlined"
+                                                color="warning"
+                                                onClick={() => onFillMissing(day.date, slot)}
+                                                data-testid={`shift-missing-${day.date}-${slot}`}
+                                            >
+                                                {`${SHIFT_LABELS[slot]}を入力`}
+                                            </Button>
+                                        ))}
+                                    </Stack>
+                                </Stack>
+                            ))}
+                        </Stack>
+                    ) : null}
+                </Stack>
+            </Paper>
+
+            {groups.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                    登録済みシフトはありません
+                </Typography>
+            ) : (
+                <TableContainer component={Paper} data-testid="shift-list">
+                    <Table size="small">
                     <TableHead>
                         <TableRow>
                             <TableCell>日付</TableCell>
@@ -154,8 +319,9 @@ const ShiftList = ({ refreshKey }: { refreshKey: number }) => {
                             </TableRow>
                         ))}
                     </TableBody>
-                </Table>
-            </TableContainer>
+                    </Table>
+                </TableContainer>
+            )}
 
             {/* ソースプレビューダイアログ */}
             <Dialog
@@ -246,7 +412,7 @@ const ShiftList = ({ refreshKey }: { refreshKey: number }) => {
                     {snackbar.message}
                 </Alert>
             </Snackbar>
-        </>
+        </Stack>
     );
 };
 

--- a/app/tweet-tagger/src/app/client-component/ShiftPageContent.tsx
+++ b/app/tweet-tagger/src/app/client-component/ShiftPageContent.tsx
@@ -1,19 +1,40 @@
 "use client";
 
 import { useState } from "react";
-import { Divider, Typography } from "@mui/material";
+import { Box, Divider, Typography } from "@mui/material";
 import ShiftEditor from "app/client-component/UnifiedShiftEditor";
 import ShiftList from "app/client-component/ShiftList";
+import { ShiftSlot } from "@iba-cast-gallery/types";
 
 const ShiftPageContent = () => {
     const [refreshKey, setRefreshKey] = useState(0);
+    const [selectionRequest, setSelectionRequest] = useState<{
+        date: string;
+        slot: ShiftSlot;
+        requestId: number;
+    } | null>(null);
+
+    const fillMissingShift = (date: string, slot: ShiftSlot) => {
+        setSelectionRequest({ date, slot, requestId: Date.now() });
+        window.requestAnimationFrame(() => {
+            document.getElementById("shift-editor")?.scrollIntoView({
+                behavior: "smooth",
+                block: "start",
+            });
+        });
+    };
 
     return (
         <>
-            <ShiftEditor onSaved={() => setRefreshKey((k) => k + 1)} />
+            <Box id="shift-editor" sx={{ scrollMarginTop: 16 }}>
+                <ShiftEditor
+                    onSaved={() => setRefreshKey((k) => k + 1)}
+                    selectionRequest={selectionRequest}
+                />
+            </Box>
             <Divider sx={{ my: 4 }} />
             <Typography variant="h6" sx={{ mb: 2 }}>登録済みシフト一覧</Typography>
-            <ShiftList refreshKey={refreshKey} />
+            <ShiftList refreshKey={refreshKey} onFillMissing={fillMissingShift} />
         </>
     );
 };

--- a/app/tweet-tagger/src/app/client-component/ShiftPageContent.tsx
+++ b/app/tweet-tagger/src/app/client-component/ShiftPageContent.tsx
@@ -11,11 +11,21 @@ const ShiftPageContent = () => {
     const [selectionRequest, setSelectionRequest] = useState<{
         date: string;
         slot: ShiftSlot;
+        sourcePostId: string | null;
         requestId: number;
     } | null>(null);
 
-    const fillMissingShift = (date: string, slot: ShiftSlot) => {
-        setSelectionRequest({ date, slot, requestId: Date.now() });
+    const fillMissingShift = (
+        date: string,
+        slot: ShiftSlot,
+        sourcePostId: string | null,
+    ) => {
+        setSelectionRequest({
+            date,
+            slot,
+            sourcePostId,
+            requestId: Date.now(),
+        });
         window.requestAnimationFrame(() => {
             document.getElementById("shift-editor")?.scrollIntoView({
                 behavior: "smooth",

--- a/app/tweet-tagger/src/app/client-component/ShiftPostCandidateDialog.tsx
+++ b/app/tweet-tagger/src/app/client-component/ShiftPostCandidateDialog.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import CloseIcon from "@mui/icons-material/Close";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    Link,
+    Paper,
+    Stack,
+    Typography,
+} from "@mui/material";
+import { ShiftSlot } from "@iba-cast-gallery/types";
+import type { ShiftPostCandidate } from "@iba-cast-gallery/types";
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+const Tweet = dynamic(
+    () => import("../../components/tweet/swr").then((module) => module.Tweet),
+    { loading: () => <CircularProgress size={24} /> },
+);
+
+const SHIFT_LABELS: Record<ShiftSlot, string> = {
+    [ShiftSlot.OPEN]: "オープン",
+    [ShiftSlot.EVENING]: "夕方",
+    [ShiftSlot.NIGHT]: "夜",
+};
+
+export type MissingShiftTarget = {
+    date: string;
+    dayOfWeek: string;
+    slot: ShiftSlot;
+};
+
+type ShiftPostCandidateDialogProps = {
+    target: MissingShiftTarget | null;
+    onClose: () => void;
+    onSelect: (sourcePostId: string | null) => void;
+};
+
+const POST_TIME_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+});
+
+const formatPostedAt = (postedAt: string) =>
+    POST_TIME_FORMATTER.format(new Date(postedAt));
+
+const formatDifference = (minutes: number) => {
+    if (minutes < 60) {
+        return `基準時刻から${minutes}分差`;
+    }
+
+    const hours = Math.floor(minutes / 60);
+    const remainder = minutes % 60;
+    return remainder === 0
+        ? `基準時刻から${hours}時間差`
+        : `基準時刻から${hours}時間${remainder}分差`;
+};
+
+const ShiftPostCandidateDialog = ({
+    target,
+    onClose,
+    onSelect,
+}: ShiftPostCandidateDialogProps) => {
+    const [candidates, setCandidates] = useState<ShiftPostCandidate[]>([]);
+    const [previewPostId, setPreviewPostId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        if (!target) {
+            setCandidates([]);
+            setPreviewPostId(null);
+            setError("");
+            return;
+        }
+
+        const controller = new AbortController();
+        setIsLoading(true);
+        setCandidates([]);
+        setPreviewPostId(null);
+        setError("");
+
+        const loadCandidates = async () => {
+            try {
+                const response = await fetch(
+                    `/api/posts/shift-candidates?date=${encodeURIComponent(target.date)}&shift=${encodeURIComponent(target.slot)}`,
+                    { signal: controller.signal },
+                );
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
+                }
+                const data = (await response.json()) as ShiftPostCandidate[];
+                setCandidates(data);
+            } catch (fetchError) {
+                if (fetchError instanceof DOMException && fetchError.name === "AbortError") {
+                    return;
+                }
+                console.error("Error loading shift post candidates:", fetchError);
+                setError("候補ポストの読み込みに失敗しました");
+            } finally {
+                if (!controller.signal.aborted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        void loadCandidates();
+        return () => controller.abort();
+    }, [target]);
+
+    return (
+        <Dialog
+            open={target !== null}
+            onClose={onClose}
+            maxWidth="md"
+            fullWidth
+            data-testid="shift-candidate-dialog"
+        >
+            <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Box sx={{ flexGrow: 1 }}>
+                    {target
+                        ? `${target.date} (${target.dayOfWeek}) ${SHIFT_LABELS[target.slot]}の情報源`
+                        : "シフト情報源"}
+                </Box>
+                <IconButton onClick={onClose} size="small" aria-label="閉じる">
+                    <CloseIcon />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent dividers>
+                <Stack spacing={2}>
+                    <Typography variant="body2" color="text.secondary">
+                        同じ日に登録された未使用のギャラリーポストを、近い時間帯から表示しています。
+                    </Typography>
+
+                    {isLoading ? (
+                        <Stack direction="row" spacing={1} alignItems="center">
+                            <CircularProgress size={20} />
+                            <Typography variant="body2">候補を探しています...</Typography>
+                        </Stack>
+                    ) : null}
+                    {error ? <Alert severity="error">{error}</Alert> : null}
+                    {!isLoading && !error && candidates.length === 0 ? (
+                        <Alert severity="info">
+                            この日に利用できる既存ポストは見つかりませんでした。
+                        </Alert>
+                    ) : null}
+
+                    {candidates.map((candidate) => (
+                        <Paper
+                            key={candidate.id}
+                            variant="outlined"
+                            sx={{ p: 2 }}
+                            data-testid={`shift-candidate-${candidate.id}`}
+                        >
+                            <Stack spacing={1.5}>
+                                <Stack
+                                    direction={{ xs: "column", sm: "row" }}
+                                    spacing={1}
+                                    alignItems={{ xs: "flex-start", sm: "center" }}
+                                    justifyContent="space-between"
+                                >
+                                    <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                                        <Chip
+                                            label={`${formatPostedAt(candidate.postedAt)}投稿`}
+                                            size="small"
+                                        />
+                                        <Chip
+                                            label={SHIFT_LABELS[candidate.inferredShift]}
+                                            color={
+                                                candidate.inferredShift === target?.slot
+                                                    ? "success"
+                                                    : "default"
+                                            }
+                                            variant={
+                                                candidate.inferredShift === target?.slot
+                                                    ? "filled"
+                                                    : "outlined"
+                                            }
+                                            size="small"
+                                        />
+                                        <Chip
+                                            label={formatDifference(candidate.differenceMinutes)}
+                                            variant="outlined"
+                                            size="small"
+                                        />
+                                    </Stack>
+                                    <Link
+                                        href={`https://x.com/i/status/${candidate.id}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+                                    >
+                                        {candidate.id}
+                                        <OpenInNewIcon fontSize="inherit" />
+                                    </Link>
+                                </Stack>
+
+                                <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+                                    {candidate.taggedCasts.length > 0 ? (
+                                        candidate.taggedCasts.map((cast) => (
+                                            <Chip
+                                                key={cast.id}
+                                                label={`${cast.order}. ${cast.name}`}
+                                                size="small"
+                                                variant="outlined"
+                                            />
+                                        ))
+                                    ) : (
+                                        <Typography variant="caption" color="text.secondary">
+                                            キャストタグなし
+                                        </Typography>
+                                    )}
+                                </Stack>
+
+                                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                                    <Button
+                                        size="small"
+                                        variant={
+                                            previewPostId === candidate.id
+                                                ? "contained"
+                                                : "outlined"
+                                        }
+                                        onClick={() =>
+                                            setPreviewPostId((current) =>
+                                                current === candidate.id ? null : candidate.id,
+                                            )
+                                        }
+                                        data-testid={`shift-candidate-preview-${candidate.id}`}
+                                    >
+                                        {previewPostId === candidate.id
+                                            ? "内容を閉じる"
+                                            : "内容を確認"}
+                                    </Button>
+                                    <Button
+                                        size="small"
+                                        variant="contained"
+                                        onClick={() => onSelect(candidate.id)}
+                                        data-testid={`shift-candidate-select-${candidate.id}`}
+                                    >
+                                        このポストを使う
+                                    </Button>
+                                </Stack>
+
+                                {previewPostId === candidate.id ? (
+                                    <Box data-testid={`shift-candidate-tweet-${candidate.id}`}>
+                                        <Tweet id={candidate.id} taggedCasts={candidate.taggedCasts} />
+                                    </Box>
+                                ) : null}
+                            </Stack>
+                        </Paper>
+                    ))}
+                </Stack>
+            </DialogContent>
+            <DialogActions sx={{ px: 3, py: 2, flexWrap: "wrap" }}>
+                <Button onClick={onClose} color="inherit">
+                    キャンセル
+                </Button>
+                <Button
+                    variant="contained"
+                    onClick={() => onSelect(null)}
+                    data-testid="shift-candidate-create-new"
+                >
+                    新しいポストを登録
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default ShiftPostCandidateDialog;

--- a/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetEditor.tsx
@@ -65,6 +65,7 @@ const TweetEditor = ({ initialId }: {
       showInGallery: true,
       contentType: PostContentType.GALLERY,
       shiftSource: null,
+      excludeFromShiftRegistration: false,
       castTags: castTags,
       taggedCasts: [],
       favorites: [],

--- a/app/tweet-tagger/src/app/client-component/TweetList.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetList.tsx
@@ -1,101 +1,272 @@
 "use client";
 
-import { Post } from "@iba-cast-gallery/dao";
+import {
+    Alert,
+    Box,
+    CircularProgress,
+    FormControl,
+    Grid,
+    InputLabel,
+    MenuItem,
+    Paper,
+    Select,
+    Stack,
+    TablePagination,
+    TextField,
+    Typography,
+} from "@mui/material";
 import { PostContentType } from "@iba-cast-gallery/types";
-import { Tweet } from "components/tweet/swr";
-import { Button, Chip, CircularProgress, Grid, Typography } from "@mui/material";
-import dayjs from "dayjs";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import BlogPostPreview from "../../components/BlogPostPreview";
+import type { PostManagementSummary } from "@iba-cast-gallery/types";
+import PostManagementCard from "components/PostManagementCard";
+import {
+    useDeferredValue,
+    useEffect,
+    useMemo,
+    useState,
+} from "react";
+
+type UsageFilter = "all" | "gallery" | "blog" | "shift" | "unassigned";
+type VisibilityFilter = "all" | "visible" | "hidden" | "deleted";
+
+const INITIAL_ROWS_PER_PAGE = 12;
 
 const TweetList = () => {
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+    const [posts, setPosts] = useState<PostManagementSummary[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [query, setQuery] = useState("");
+    const [usage, setUsage] = useState<UsageFilter>("all");
+    const [visibility, setVisibility] = useState<VisibilityFilter>("all");
+    const [castId, setCastId] = useState("all");
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(INITIAL_ROWS_PER_PAGE);
+    const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase("ja"));
 
-  useEffect(() => {
-    const fetchPosts = async () => {
-      try {
-        const response = await fetch("/api/posts");
-        if (!response.ok) {
-          // エラー処理
+    useEffect(() => {
+        const controller = new AbortController();
+
+        const fetchPosts = async () => {
+            try {
+                const response = await fetch("/api/post-summaries", {
+                    signal: controller.signal,
+                });
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
+                }
+
+                const data: PostManagementSummary[] = await response.json();
+                setPosts(data);
+            } catch (fetchError) {
+                if (fetchError instanceof DOMException && fetchError.name === "AbortError") {
+                    return;
+                }
+                console.error("Error fetching post summaries:", fetchError);
+                setError("登録済みポストの読み込みに失敗しました");
+            } finally {
+                if (!controller.signal.aborted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        void fetchPosts();
+        return () => controller.abort();
+    }, []);
+
+    const casts = useMemo(() => {
+        const castMap = new Map<number, string>();
+        for (const post of posts) {
+            for (const cast of post.taggedCasts) {
+                castMap.set(cast.id, cast.name);
+            }
+            for (const shift of post.shifts) {
+                for (const cast of shift.casts) {
+                    castMap.set(cast.id, cast.name);
+                }
+            }
         }
+        return Array.from(castMap, ([id, name]) => ({ id, name })).toSorted((a, b) =>
+            a.name.localeCompare(b.name, "ja"),
+        );
+    }, [posts]);
 
-        const data: Post[] = await response.json();
-        setPosts(data);
-      } catch (error) {
-        console.error("Error fetching casts:", error);
-      }
-    };
+    const filteredPosts = useMemo(() => {
+        return posts.filter((post) => {
+            const isGallery =
+                post.contentType === PostContentType.GALLERY &&
+                (post.showInGallery || post.taggedCasts.length > 0);
+            const isBlog = post.contentType === PostContentType.BLOG;
+            const isShift = post.shiftSource !== null || post.shifts.length > 0;
 
-    fetchPosts().finally(() => {
-      setIsLoading(false);
-    });
-  }, []);
+            const matchesUsage =
+                usage === "all" ||
+                (usage === "gallery" && isGallery) ||
+                (usage === "blog" && isBlog) ||
+                (usage === "shift" && isShift) ||
+                (usage === "unassigned" && !isGallery && !isBlog && !isShift);
 
-  const router = useRouter();
-  const handleEdit = (post: Post) => {
-    router.push(`/posts/${post.id}/edit`);
-  };
+            const matchesVisibility =
+                visibility === "all" ||
+                (visibility === "visible" && post.showInGallery && !post.isDeleted) ||
+                (visibility === "hidden" && !post.showInGallery && !post.isDeleted) ||
+                (visibility === "deleted" && post.isDeleted);
 
-  return (
-    <Grid container spacing={2} className="w-full">
-      {isLoading ? (
-        <Grid container justifyContent="center" className="w-full">
-          <CircularProgress />
-        </Grid>
-      ) : (
-        posts.map((post, index) => (
-          <Grid
-            key={post.id}
-            size={{ xs: 12, md: 6, lg: 4, xl: 3 }}
-            data-testid={`tweet-list-item-${index + 1}`}
-          >
-            <div className="border p-4 rounded">
-              {!post.showInGallery && (
-                <Chip
-                  label="ドラフト"
-                  color="warning"
-                  size="small"
-                  data-testid="draft-chip"
-                  sx={{ mb: 1 }}
-                />
-              )}
-              {post.isDeleted ? (
-                <Typography variant="body2" color="error">
-                  削除済み
-                </Typography>
-              ) : post.contentType === PostContentType.BLOG ? (
-                <BlogPostPreview postId={post.id} postedAt={post.postedAt} />
-              ) : (
-                <Tweet
-                  id={post.id}
-                  taggedCasts={post.castTags
-                    .sort((a, b) => a.order - b.order)
-                    .map((castTag) => castTag.cast)}
-                />
-              )}
-              <Typography variant="body1">id: {post.id}</Typography>
-              <Typography variant="body1">
-                postedAt: {dayjs(post.postedAt).format("YYYY-MM-DD hh:mm:ss")}
-              </Typography>
-              <Typography variant="body1">
-                isDeleted: {post.isDeleted ? "true" : "false"}
-              </Typography>
-              <Button
-                onClick={() => {
-                  handleEdit(post);
-                }}
-                variant="outlined"
-              >
-                編集
-              </Button>
-            </div>
-          </Grid>
-        ))
-      )}
-    </Grid>
-  );
+            const numericCastId = Number(castId);
+            const matchesCast =
+                castId === "all" ||
+                post.taggedCasts.some((cast) => cast.id === numericCastId) ||
+                post.shifts.some((shift) =>
+                    shift.casts.some((cast) => cast.id === numericCastId),
+                );
+
+            const searchableText = [
+                post.id,
+                post.postedAt,
+                ...post.taggedCasts.map((cast) => cast.name),
+                ...post.shifts.flatMap((shift) => [
+                    shift.date,
+                    shift.dayOfWeek,
+                    ...shift.casts.map((cast) => cast.name),
+                ]),
+            ]
+                .join(" ")
+                .toLocaleLowerCase("ja");
+            const matchesQuery =
+                deferredQuery.length === 0 || searchableText.includes(deferredQuery);
+
+            return matchesUsage && matchesVisibility && matchesCast && matchesQuery;
+        });
+    }, [castId, deferredQuery, posts, usage, visibility]);
+
+    useEffect(() => {
+        setPage(0);
+    }, [castId, deferredQuery, rowsPerPage, usage, visibility]);
+
+    const visiblePosts = filteredPosts.slice(
+        page * rowsPerPage,
+        page * rowsPerPage + rowsPerPage,
+    );
+
+    if (isLoading) {
+        return (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (error) {
+        return <Alert severity="error">{error}</Alert>;
+    }
+
+    return (
+        <Stack spacing={2}>
+            <Paper variant="outlined" sx={{ p: 2 }}>
+                <Grid container spacing={2} alignItems="center">
+                    <Grid size={{ xs: 12, md: 5 }}>
+                        <TextField
+                            fullWidth
+                            size="small"
+                            label="ポストID・キャスト名・シフト日付を検索"
+                            value={query}
+                            onChange={(event) => setQuery(event.target.value)}
+                            slotProps={{ htmlInput: { "data-testid": "post-search-input" } }}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 4, md: 2 }}>
+                        <FormControl fullWidth size="small">
+                            <InputLabel id="post-usage-filter-label">登録用途</InputLabel>
+                            <Select
+                                labelId="post-usage-filter-label"
+                                label="登録用途"
+                                value={usage}
+                                onChange={(event) => setUsage(event.target.value as UsageFilter)}
+                                data-testid="post-usage-filter"
+                            >
+                                <MenuItem value="all">すべて</MenuItem>
+                                <MenuItem value="gallery">ギャラリー</MenuItem>
+                                <MenuItem value="blog">BLOG</MenuItem>
+                                <MenuItem value="shift">シフト</MenuItem>
+                                <MenuItem value="unassigned">用途未設定</MenuItem>
+                            </Select>
+                        </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 4, md: 2 }}>
+                        <FormControl fullWidth size="small">
+                            <InputLabel id="post-visibility-filter-label">表示状態</InputLabel>
+                            <Select
+                                labelId="post-visibility-filter-label"
+                                label="表示状態"
+                                value={visibility}
+                                onChange={(event) =>
+                                    setVisibility(event.target.value as VisibilityFilter)
+                                }
+                                data-testid="post-visibility-filter"
+                            >
+                                <MenuItem value="all">すべて</MenuItem>
+                                <MenuItem value="visible">ギャラリー表示中</MenuItem>
+                                <MenuItem value="hidden">ギャラリー非表示</MenuItem>
+                                <MenuItem value="deleted">削除済み</MenuItem>
+                            </Select>
+                        </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 4, md: 3 }}>
+                        <FormControl fullWidth size="small">
+                            <InputLabel id="post-cast-filter-label">キャスト</InputLabel>
+                            <Select
+                                labelId="post-cast-filter-label"
+                                label="キャスト"
+                                value={castId}
+                                onChange={(event) => setCastId(event.target.value)}
+                                data-testid="post-cast-filter"
+                            >
+                                <MenuItem value="all">すべて</MenuItem>
+                                {casts.map((cast) => (
+                                    <MenuItem key={cast.id} value={String(cast.id)}>
+                                        {cast.name}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
+                    </Grid>
+                </Grid>
+            </Paper>
+
+            <Typography variant="body2" color="text.secondary" aria-live="polite">
+                {`${filteredPosts.length}件 / 全${posts.length}件`}
+            </Typography>
+
+            {visiblePosts.length > 0 ? (
+                <Grid container spacing={2} className="w-full">
+                    {visiblePosts.map((post, index) => (
+                        <Grid
+                            key={post.id}
+                            size={{ xs: 12, lg: 6 }}
+                            data-testid={`tweet-list-item-${index + 1}`}
+                        >
+                            <PostManagementCard post={post} />
+                        </Grid>
+                    ))}
+                </Grid>
+            ) : (
+                <Alert severity="info">条件に一致するポストはありません</Alert>
+            )}
+
+            <TablePagination
+                component="div"
+                count={filteredPosts.length}
+                page={page}
+                onPageChange={(_, nextPage) => setPage(nextPage)}
+                rowsPerPage={rowsPerPage}
+                onRowsPerPageChange={(event) => setRowsPerPage(Number(event.target.value))}
+                rowsPerPageOptions={[12, 24, 48]}
+                labelRowsPerPage="1ページの件数"
+                labelDisplayedRows={({ from, to, count }) => `${from}–${to} / ${count}`}
+                showFirstButton
+                showLastButton
+            />
+        </Stack>
+    );
 };
 
 export default TweetList;

--- a/app/tweet-tagger/src/app/client-component/TweetList.tsx
+++ b/app/tweet-tagger/src/app/client-component/TweetList.tsx
@@ -19,13 +19,20 @@ import { PostContentType } from "@iba-cast-gallery/types";
 import type { PostManagementSummary } from "@iba-cast-gallery/types";
 import PostManagementCard from "components/PostManagementCard";
 import {
+    useCallback,
     useDeferredValue,
     useEffect,
     useMemo,
     useState,
 } from "react";
 
-type UsageFilter = "all" | "gallery" | "blog" | "shift" | "unassigned";
+type UsageFilter =
+    | "all"
+    | "gallery"
+    | "gallery-without-shift"
+    | "blog"
+    | "shift"
+    | "unassigned";
 type VisibilityFilter = "all" | "visible" | "hidden" | "deleted";
 
 const INITIAL_ROWS_PER_PAGE = 12;
@@ -41,6 +48,19 @@ const TweetList = () => {
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(INITIAL_ROWS_PER_PAGE);
     const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase("ja"));
+
+    const handleShiftRegistrationExclusionChange = useCallback(
+        (postId: string, excludeFromShiftRegistration: boolean) => {
+            setPosts((current) =>
+                current.map((item) =>
+                    item.id === postId
+                        ? { ...item, excludeFromShiftRegistration }
+                        : item,
+                ),
+            );
+        },
+        [],
+    );
 
     useEffect(() => {
         const controller = new AbortController();
@@ -97,10 +117,16 @@ const TweetList = () => {
                 (post.showInGallery || post.taggedCasts.length > 0);
             const isBlog = post.contentType === PostContentType.BLOG;
             const isShift = post.shiftSource !== null || post.shifts.length > 0;
+            const needsShiftRegistration =
+                isGallery &&
+                !isShift &&
+                !post.isDeleted &&
+                !post.excludeFromShiftRegistration;
 
             const matchesUsage =
                 usage === "all" ||
                 (usage === "gallery" && isGallery) ||
+                (usage === "gallery-without-shift" && needsShiftRegistration) ||
                 (usage === "blog" && isBlog) ||
                 (usage === "shift" && isShift) ||
                 (usage === "unassigned" && !isGallery && !isBlog && !isShift);
@@ -185,6 +211,9 @@ const TweetList = () => {
                             >
                                 <MenuItem value="all">すべて</MenuItem>
                                 <MenuItem value="gallery">ギャラリー</MenuItem>
+                                <MenuItem value="gallery-without-shift">
+                                    ギャラリー（シフト未登録）
+                                </MenuItem>
                                 <MenuItem value="blog">BLOG</MenuItem>
                                 <MenuItem value="shift">シフト</MenuItem>
                                 <MenuItem value="unassigned">用途未設定</MenuItem>
@@ -244,7 +273,12 @@ const TweetList = () => {
                             size={{ xs: 12, lg: 6 }}
                             data-testid={`tweet-list-item-${index + 1}`}
                         >
-                            <PostManagementCard post={post} />
+                            <PostManagementCard
+                                post={post}
+                                onShiftRegistrationExclusionChange={
+                                    handleShiftRegistrationExclusionChange
+                                }
+                            />
                         </Grid>
                     ))}
                 </Grid>

--- a/app/tweet-tagger/src/app/client-component/UnifiedShiftEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/UnifiedShiftEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
     Alert,
     Button,
@@ -30,6 +30,7 @@ const SHIFT_LABELS: Record<ShiftSlot, string> = {
 type ShiftSelectionRequest = {
     date: string;
     slot: ShiftSlot;
+    sourcePostId?: string | null;
     requestId: number;
 };
 
@@ -73,33 +74,47 @@ const UnifiedShiftEditor = ({
         setSlot(selectionRequest.slot);
     }, [selectionRequest]);
 
-    const fetchExisting = useCallback(async () => {
+    useEffect(() => {
         if (!date?.isValid()) {
             return;
         }
 
         const dateString = date.format("YYYY-MM-DD");
-        try {
-            const response = await fetch(
-                `/api/shifts?date=${dateString}&shift=${slot}`,
-            );
-            if (!response.ok) {
-                return;
-            }
-            const data: {
-                castIds: number[];
-                sourcePostId: string | null;
-            } = await response.json();
-            setSelectedCastIds(data.castIds);
-            setTweetInput(data.sourcePostId ?? "");
-        } catch (error) {
-            console.error(error);
-        }
-    }, [date, slot]);
+        const controller = new AbortController();
+        const fetchExisting = async () => {
+            try {
+                const response = await fetch(
+                    `/api/shifts?date=${dateString}&shift=${slot}`,
+                    { signal: controller.signal },
+                );
+                if (!response.ok) {
+                    return;
+                }
+                const data: {
+                    castIds: number[];
+                    sourcePostId: string | null;
+                } = await response.json();
+                setSelectedCastIds(data.castIds);
 
-    useEffect(() => {
+                const isRequestedShift =
+                    selectionRequest?.date === dateString &&
+                    selectionRequest.slot === slot;
+                setTweetInput(
+                    isRequestedShift && selectionRequest.sourcePostId !== undefined
+                        ? selectionRequest.sourcePostId ?? ""
+                        : data.sourcePostId ?? "",
+                );
+            } catch (error) {
+                if (error instanceof DOMException && error.name === "AbortError") {
+                    return;
+                }
+                console.error(error);
+            }
+        };
+
         void fetchExisting();
-    }, [fetchExisting]);
+        return () => controller.abort();
+    }, [date, selectionRequest, slot]);
 
     const save = async () => {
         if (!date?.isValid() || saving) {

--- a/app/tweet-tagger/src/app/client-component/UnifiedShiftEditor.tsx
+++ b/app/tweet-tagger/src/app/client-component/UnifiedShiftEditor.tsx
@@ -27,7 +27,19 @@ const SHIFT_LABELS: Record<ShiftSlot, string> = {
     [ShiftSlot.NIGHT]: "夜",
 };
 
-const UnifiedShiftEditor = ({ onSaved }: { onSaved?: () => void }) => {
+type ShiftSelectionRequest = {
+    date: string;
+    slot: ShiftSlot;
+    requestId: number;
+};
+
+const UnifiedShiftEditor = ({
+    onSaved,
+    selectionRequest,
+}: {
+    onSaved?: () => void;
+    selectionRequest?: ShiftSelectionRequest | null;
+}) => {
     const [casts, setCasts] = useState<CastOption[]>([]);
     const [tweetInput, setTweetInput] = useState("");
     const [tweetId, setTweetId] = useState("");
@@ -51,6 +63,15 @@ const UnifiedShiftEditor = ({ onSaved }: { onSaved?: () => void }) => {
     useEffect(() => {
         setTweetId(extractPostId(tweetInput) ?? "");
     }, [tweetInput]);
+
+    useEffect(() => {
+        if (!selectionRequest) {
+            return;
+        }
+
+        setDate(dayjs(selectionRequest.date));
+        setSlot(selectionRequest.slot);
+    }, [selectionRequest]);
 
     const fetchExisting = useCallback(async () => {
         if (!date?.isValid()) {

--- a/app/tweet-tagger/src/components/CastChip.tsx
+++ b/app/tweet-tagger/src/components/CastChip.tsx
@@ -1,7 +1,9 @@
-import { Cast } from "@iba-cast-gallery/dao";
+import type { Cast } from "@iba-cast-gallery/dao";
 import { Chip } from "@mui/material";
 
-const CastChip: React.FC<{ cast: Cast, dataTestId?:string}> = ({ cast, dataTestId }) => {
+export type CastChipCast = Pick<Cast, "id" | "name">;
+
+const CastChip: React.FC<{ cast: CastChipCast, dataTestId?:string}> = ({ cast, dataTestId }) => {
     return (
         <Chip label={cast.name} size="small" data-testid={dataTestId} />
     );

--- a/app/tweet-tagger/src/components/PostManagementCard.tsx
+++ b/app/tweet-tagger/src/components/PostManagementCard.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import {
+    Box,
+    Button,
+    Card,
+    CardActions,
+    CardContent,
+    Chip,
+    CircularProgress,
+    Collapse,
+    Divider,
+    Link,
+    Stack,
+    Typography,
+} from "@mui/material";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import { PostContentType, ShiftSlot } from "@iba-cast-gallery/types";
+import type { PostManagementSummary } from "@iba-cast-gallery/types";
+import dayjs from "dayjs";
+import dynamic from "next/dynamic";
+import NextLink from "next/link";
+import { useState } from "react";
+
+const BlogPostPreview = dynamic(() => import("components/BlogPostPreview"), {
+    loading: () => <CircularProgress size={24} />,
+});
+const TweetPreview = dynamic(
+    () => import("components/tweet/swr").then((module) => module.Tweet),
+    { loading: () => <CircularProgress size={24} /> },
+);
+
+const SHIFT_LABELS: Record<ShiftSlot, string> = {
+    [ShiftSlot.OPEN]: "オープン",
+    [ShiftSlot.EVENING]: "夕方",
+    [ShiftSlot.NIGHT]: "夜",
+};
+
+const PostManagementCard = ({ post }: { post: PostManagementSummary }) => {
+    const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+    const isGallery =
+        post.contentType === PostContentType.GALLERY &&
+        (post.showInGallery || post.taggedCasts.length > 0);
+    const isBlog = post.contentType === PostContentType.BLOG;
+    const isShift = post.shiftSource !== null || post.shifts.length > 0;
+
+    const visibilityLabel = post.isDeleted
+        ? "削除済み"
+        : post.showInGallery
+            ? "表示中"
+            : isShift
+                ? "ギャラリー非表示"
+                : "ドラフト";
+    const visibilityColor = post.isDeleted
+        ? "error"
+        : post.showInGallery
+            ? "success"
+            : "warning";
+
+    return (
+        <Card
+            variant="outlined"
+            data-testid={`post-summary-${post.id}`}
+            sx={{ height: "100%", display: "flex", flexDirection: "column" }}
+        >
+            <CardContent sx={{ flexGrow: 1 }}>
+                <Stack spacing={2}>
+                    <Stack
+                        direction={{ xs: "column", sm: "row" }}
+                        spacing={1}
+                        alignItems={{ xs: "flex-start", sm: "center" }}
+                        justifyContent="space-between"
+                    >
+                        <Typography variant="body2" color="text.secondary">
+                            {dayjs(post.postedAt).format("YYYY-MM-DD HH:mm:ss")}
+                        </Typography>
+                        <Chip
+                            label={visibilityLabel}
+                            color={visibilityColor}
+                            size="small"
+                        />
+                    </Stack>
+
+                    <Box>
+                        <Typography variant="caption" color="text.secondary">
+                            ポストID
+                        </Typography>
+                        <Link
+                            href={`https://x.com/i/status/${post.id}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
+                        >
+                            {post.id}
+                            <OpenInNewIcon fontSize="inherit" />
+                        </Link>
+                    </Box>
+
+                    <Box>
+                        <Typography variant="caption" color="text.secondary">
+                            登録用途
+                        </Typography>
+                        <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" sx={{ mt: 0.5 }}>
+                            {isGallery ? <Chip label="ギャラリー" color="primary" size="small" /> : null}
+                            {isBlog ? <Chip label="BLOG" color="secondary" size="small" /> : null}
+                            {isShift ? <Chip label="シフト" color="info" size="small" /> : null}
+                            {!isGallery && !isBlog && !isShift ? (
+                                <Chip label="用途未設定" variant="outlined" size="small" />
+                            ) : null}
+                            {post.shiftSource ? (
+                                <Chip
+                                    label={post.shiftSource === "pending" ? "シフト解析待ち" : "シフト解析済み"}
+                                    variant="outlined"
+                                    size="small"
+                                />
+                            ) : null}
+                        </Stack>
+                    </Box>
+
+                    <Box>
+                        <Typography variant="caption" color="text.secondary">
+                            ギャラリー／BLOGのキャストタグ
+                        </Typography>
+                        <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" sx={{ mt: 0.5 }}>
+                            {post.taggedCasts.length > 0 ? (
+                                post.taggedCasts.map((cast) => (
+                                    <Chip key={cast.id} label={`${cast.order}. ${cast.name}`} size="small" />
+                                ))
+                            ) : (
+                                <Typography variant="body2" color="text.secondary">
+                                    なし
+                                </Typography>
+                            )}
+                        </Stack>
+                    </Box>
+
+                    <Box>
+                        <Typography variant="caption" color="text.secondary">
+                            シフト登録
+                        </Typography>
+                        <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                            {post.shifts.length > 0 ? (
+                                post.shifts.map((shift) => (
+                                    <Typography
+                                        key={`${shift.date}-${shift.shift}`}
+                                        variant="body2"
+                                        data-testid={`post-shift-${post.id}-${shift.date}-${shift.shift}`}
+                                    >
+                                        {`${shift.date} (${shift.dayOfWeek}) ${SHIFT_LABELS[shift.shift]}：${shift.casts.map((cast) => cast.name).join("、")}`}
+                                    </Typography>
+                                ))
+                            ) : (
+                                <Typography variant="body2" color="text.secondary">
+                                    なし
+                                </Typography>
+                            )}
+                        </Stack>
+                    </Box>
+                </Stack>
+            </CardContent>
+
+            <Divider />
+            <CardActions sx={{ px: 2, py: 1.5 }}>
+                <Button
+                    size="small"
+                    onClick={() => setIsPreviewOpen((current) => !current)}
+                    aria-expanded={isPreviewOpen}
+                    data-testid={`post-preview-toggle-${post.id}`}
+                >
+                    {isPreviewOpen ? "プレビューを閉じる" : "Xプレビュー"}
+                </Button>
+                <Button
+                    component={NextLink}
+                    href={`/posts/${post.id}/edit`}
+                    size="small"
+                    variant="outlined"
+                >
+                    編集
+                </Button>
+            </CardActions>
+
+            <Collapse in={isPreviewOpen} unmountOnExit>
+                <Divider />
+                <Box sx={{ p: 2 }}>
+                    {post.contentType === PostContentType.BLOG ? (
+                        <BlogPostPreview postId={post.id} postedAt={post.postedAt} />
+                    ) : (
+                        <TweetPreview id={post.id} taggedCasts={post.taggedCasts} />
+                    )}
+                </Box>
+            </Collapse>
+        </Card>
+    );
+};
+
+export default PostManagementCard;

--- a/app/tweet-tagger/src/components/PostManagementCard.tsx
+++ b/app/tweet-tagger/src/components/PostManagementCard.tsx
@@ -21,7 +21,7 @@ import type { PostManagementSummary } from "@iba-cast-gallery/types";
 import dayjs from "dayjs";
 import dynamic from "next/dynamic";
 import NextLink from "next/link";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const BlogPostPreview = dynamic(() => import("components/BlogPostPreview"), {
     loading: () => <CircularProgress size={24} />,
@@ -49,7 +49,9 @@ const PostManagementCard = ({
     post,
     onShiftRegistrationExclusionChange,
 }: PostManagementCardProps) => {
-    const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+    const cardRef = useRef<HTMLDivElement | null>(null);
+    const [hasEnteredViewport, setHasEnteredViewport] = useState(false);
+    const [isPreviewOpen, setIsPreviewOpen] = useState(true);
     const [isUpdatingShiftExclusion, setIsUpdatingShiftExclusion] = useState(false);
     const [shiftExclusionError, setShiftExclusionError] = useState("");
     const isGallery =
@@ -58,6 +60,41 @@ const PostManagementCard = ({
     const isBlog = post.contentType === PostContentType.BLOG;
     const isShift = post.shiftSource !== null || post.shifts.length > 0;
     const canChangeShiftExclusion = isGallery && !isShift && !post.isDeleted;
+
+    useEffect(() => {
+        const card = cardRef.current;
+        if (!card || hasEnteredViewport) {
+            return;
+        }
+
+        if (!("IntersectionObserver" in window)) {
+            setHasEnteredViewport(true);
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (!entry?.isIntersecting) {
+                    return;
+                }
+                setHasEnteredViewport(true);
+                observer.disconnect();
+            },
+            { rootMargin: "400px 0px" },
+        );
+        observer.observe(card);
+        return () => observer.disconnect();
+    }, [hasEnteredViewport]);
+
+    const togglePreview = () => {
+        if (!hasEnteredViewport) {
+            setHasEnteredViewport(true);
+            setIsPreviewOpen(true);
+            return;
+        }
+        setHasEnteredViewport(true);
+        setIsPreviewOpen((current) => !current);
+    };
 
     const updateShiftRegistrationExclusion = async () => {
         if (isUpdatingShiftExclusion) {
@@ -102,6 +139,7 @@ const PostManagementCard = ({
 
     return (
         <Card
+            ref={cardRef}
             variant="outlined"
             data-testid={`post-summary-${post.id}`}
             sx={{ height: "100%", display: "flex", flexDirection: "column" }}
@@ -231,11 +269,13 @@ const PostManagementCard = ({
             <CardActions sx={{ px: 2, py: 1.5, flexWrap: "wrap", gap: 0.5 }}>
                 <Button
                     size="small"
-                    onClick={() => setIsPreviewOpen((current) => !current)}
-                    aria-expanded={isPreviewOpen}
+                    onClick={togglePreview}
+                    aria-expanded={hasEnteredViewport && isPreviewOpen}
                     data-testid={`post-preview-toggle-${post.id}`}
                 >
-                    {isPreviewOpen ? "プレビューを閉じる" : "Xプレビュー"}
+                    {hasEnteredViewport && isPreviewOpen
+                        ? "ポストを閉じる"
+                        : "ポストを表示"}
                 </Button>
                 <Button
                     component={NextLink}
@@ -266,7 +306,7 @@ const PostManagementCard = ({
                 ) : null}
             </CardActions>
 
-            <Collapse in={isPreviewOpen} unmountOnExit>
+            <Collapse in={hasEnteredViewport && isPreviewOpen} unmountOnExit>
                 <Divider />
                 <Box sx={{ p: 2 }}>
                     {post.contentType === PostContentType.BLOG ? (

--- a/app/tweet-tagger/src/components/PostManagementCard.tsx
+++ b/app/tweet-tagger/src/components/PostManagementCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+    Alert,
     Box,
     Button,
     Card,
@@ -36,13 +37,55 @@ const SHIFT_LABELS: Record<ShiftSlot, string> = {
     [ShiftSlot.NIGHT]: "夜",
 };
 
-const PostManagementCard = ({ post }: { post: PostManagementSummary }) => {
+type PostManagementCardProps = {
+    post: PostManagementSummary;
+    onShiftRegistrationExclusionChange: (
+        postId: string,
+        excludeFromShiftRegistration: boolean,
+    ) => void;
+};
+
+const PostManagementCard = ({
+    post,
+    onShiftRegistrationExclusionChange,
+}: PostManagementCardProps) => {
     const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+    const [isUpdatingShiftExclusion, setIsUpdatingShiftExclusion] = useState(false);
+    const [shiftExclusionError, setShiftExclusionError] = useState("");
     const isGallery =
         post.contentType === PostContentType.GALLERY &&
         (post.showInGallery || post.taggedCasts.length > 0);
     const isBlog = post.contentType === PostContentType.BLOG;
     const isShift = post.shiftSource !== null || post.shifts.length > 0;
+    const canChangeShiftExclusion = isGallery && !isShift && !post.isDeleted;
+
+    const updateShiftRegistrationExclusion = async () => {
+        if (isUpdatingShiftExclusion) {
+            return;
+        }
+
+        const nextValue = !post.excludeFromShiftRegistration;
+        setIsUpdatingShiftExclusion(true);
+        setShiftExclusionError("");
+        try {
+            const response = await fetch(`/api/posts/${post.id}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    excludeFromShiftRegistration: nextValue,
+                }),
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            onShiftRegistrationExclusionChange(post.id, nextValue);
+        } catch (error) {
+            console.error("Error updating shift registration exclusion:", error);
+            setShiftExclusionError("シフト登録対象の更新に失敗しました");
+        } finally {
+            setIsUpdatingShiftExclusion(false);
+        }
+    };
 
     const visibilityLabel = post.isDeleted
         ? "削除済み"
@@ -104,6 +147,26 @@ const PostManagementCard = ({ post }: { post: PostManagementSummary }) => {
                             {isGallery ? <Chip label="ギャラリー" color="primary" size="small" /> : null}
                             {isBlog ? <Chip label="BLOG" color="secondary" size="small" /> : null}
                             {isShift ? <Chip label="シフト" color="info" size="small" /> : null}
+                            {canChangeShiftExclusion ? (
+                                <Chip
+                                    label={
+                                        post.excludeFromShiftRegistration
+                                            ? "シフト登録対象外"
+                                            : "シフト未登録"
+                                    }
+                                    color={
+                                        post.excludeFromShiftRegistration
+                                            ? "default"
+                                            : "warning"
+                                    }
+                                    variant={
+                                        post.excludeFromShiftRegistration
+                                            ? "outlined"
+                                            : "filled"
+                                    }
+                                    size="small"
+                                />
+                            ) : null}
                             {!isGallery && !isBlog && !isShift ? (
                                 <Chip label="用途未設定" variant="outlined" size="small" />
                             ) : null}
@@ -160,7 +223,12 @@ const PostManagementCard = ({ post }: { post: PostManagementSummary }) => {
             </CardContent>
 
             <Divider />
-            <CardActions sx={{ px: 2, py: 1.5 }}>
+            {shiftExclusionError ? (
+                <Alert severity="error" sx={{ mx: 2, mt: 1.5 }}>
+                    {shiftExclusionError}
+                </Alert>
+            ) : null}
+            <CardActions sx={{ px: 2, py: 1.5, flexWrap: "wrap", gap: 0.5 }}>
                 <Button
                     size="small"
                     onClick={() => setIsPreviewOpen((current) => !current)}
@@ -177,6 +245,25 @@ const PostManagementCard = ({ post }: { post: PostManagementSummary }) => {
                 >
                     編集
                 </Button>
+                {canChangeShiftExclusion ? (
+                    <Button
+                        size="small"
+                        color={
+                            post.excludeFromShiftRegistration
+                                ? "primary"
+                                : "inherit"
+                        }
+                        onClick={() => void updateShiftRegistrationExclusion()}
+                        disabled={isUpdatingShiftExclusion}
+                        data-testid={`post-shift-exclusion-toggle-${post.id}`}
+                    >
+                        {isUpdatingShiftExclusion
+                            ? "更新中..."
+                            : post.excludeFromShiftRegistration
+                                ? "シフト登録候補に戻す"
+                                : "シフト登録対象外にする"}
+                    </Button>
+                ) : null}
             </CardActions>
 
             <Collapse in={isPreviewOpen} unmountOnExit>

--- a/app/tweet-tagger/src/components/tweet/swr.tsx
+++ b/app/tweet-tagger/src/components/tweet/swr.tsx
@@ -9,13 +9,13 @@ import {
 } from './twitter-theme/components'
 import { type TweetCoreProps } from './utils'
 import { useTweet } from 'react-tweet'
-import { Cast } from "@iba-cast-gallery/dao";
+import type { CastChipCast } from "components/CastChip";
 
 export type TweetProps = Omit<TweetCoreProps, 'id'> & {
   fallback?: ReactNode
   components?: TwitterComponents
   fetchOptions?: RequestInit
-  taggedCasts: Cast[];
+  taggedCasts: CastChipCast[];
 } & (
     | {
         id: string

--- a/app/tweet-tagger/src/components/tweet/tweet.tsx
+++ b/app/tweet-tagger/src/components/tweet/tweet.tsx
@@ -6,7 +6,7 @@ import {
   TweetSkeleton,
 } from './twitter-theme/components'
 import type { TweetProps } from './swr'
-import { Cast } from '@iba-cast-gallery/dao'
+import type { CastChipCast } from 'components/CastChip'
 
 // This is not ideal because we don't use the `apiUrl` prop here and `id` is required. But as the
 // type is shared with the SWR version when the Tweet component is imported, we need to have a type
@@ -14,7 +14,7 @@ import { Cast } from '@iba-cast-gallery/dao'
 export type { TweetProps }
 
 type TweetContentProps = Omit<TweetProps, 'fallback'> &{
-  taggedCasts: Cast[];
+  taggedCasts: CastChipCast[];
 }
 
 const TweetContent = async ({

--- a/app/tweet-tagger/src/components/tweet/twitter-theme/embedded-tweet.tsx
+++ b/app/tweet-tagger/src/components/tweet/twitter-theme/embedded-tweet.tsx
@@ -12,13 +12,12 @@ import { QuotedTweet } from "./quoted-tweet/index";
 import { enrichTweet } from "../utils";
 import { useMemo, useState } from "react";
 import { Button, Stack, Grid } from "@mui/material";
-import CastChip from "components/CastChip";
-import { Cast } from "@iba-cast-gallery/dao";
+import CastChip, { type CastChipCast } from "components/CastChip";
 
 type Props = {
   tweet: Tweet;
   components?: Omit<TwitterComponents, "TweetNotFound">;
-  taggedCasts: Cast[];
+  taggedCasts: CastChipCast[];
 };
 
 export const EmbeddedTweet = ({ tweet: t, components, taggedCasts }: Props) => {

--- a/app/tweet-tagger/src/services/postRegistrationService.ts
+++ b/app/tweet-tagger/src/services/postRegistrationService.ts
@@ -168,6 +168,9 @@ export async function registerPostWithDestinations(
                     ? ShiftSourceStatus.DONE
                     : ShiftSourceStatus.PENDING
                 : existing?.shiftSource ?? null,
+            excludeFromShiftRegistration: request.destinations.shift
+                ? false
+                : existing?.excludeFromShiftRegistration ?? false,
         };
 
         if (existing) {

--- a/app/tweet-tagger/src/services/postService.ts
+++ b/app/tweet-tagger/src/services/postService.ts
@@ -105,6 +105,7 @@ export async function getPostManagementSummaries(): Promise<PostManagementSummar
         showInGallery: post.showInGallery,
         contentType: post.contentType,
         shiftSource: post.shiftSource,
+        excludeFromShiftRegistration: post.excludeFromShiftRegistration,
         taggedCasts: [...(post.castTags ?? [])]
             .sort((a, b) => a.order - b.order)
             .map((tag) => ({
@@ -229,5 +230,25 @@ export async function deletePostById(postId: string): Promise<boolean> {
     const postRepository: Repository<Post> = appDataSource.getRepository(Post);
     const result = await postRepository.delete(postId);
 
+    return result.affected !== 0;
+}
+
+/**
+ * ギャラリーポストをシフト登録候補へ表示するかどうかを更新する。
+ */
+export async function updatePostShiftRegistrationExclusion(
+    postId: string,
+    excludeFromShiftRegistration: boolean,
+): Promise<boolean> {
+    await initializeDatabase();
+    const postRepository: Repository<Post> = appDataSource.getRepository(Post);
+    const result = await postRepository.update(postId, {
+        excludeFromShiftRegistration,
+    });
+
+    logger.info(
+        { postId, excludeFromShiftRegistration },
+        "ポストのシフト登録候補除外状態を更新",
+    );
     return result.affected !== 0;
 }

--- a/app/tweet-tagger/src/services/postService.ts
+++ b/app/tweet-tagger/src/services/postService.ts
@@ -1,7 +1,12 @@
+import "server-only";
 import 'reflect-metadata';
 import { initializeDatabase, appDataSource } from "../data-source";
-import { PostCastTag, Repository } from "@iba-cast-gallery/dao";
-import { PostContentType } from "@iba-cast-gallery/types";
+import { PostCastTag, Repository, Shift } from "@iba-cast-gallery/dao";
+import {
+    PostContentType,
+    ShiftSlot,
+} from "@iba-cast-gallery/types";
+import type { PostManagementSummary } from "@iba-cast-gallery/types";
 import { Post } from "@iba-cast-gallery/dao";
 import logger from "../logger";
 import { getPostCreatedAtFromId } from "utils/postId";
@@ -20,6 +25,96 @@ export async function getAllPosts(): Promise<Post[]> {
     });
 
     return posts;
+}
+
+/**
+ * 管理画面向けに、ポストへ登録されている用途・タグ・シフトをまとめて取得する。
+ */
+export async function getPostManagementSummaries(): Promise<PostManagementSummary[]> {
+    await initializeDatabase();
+
+    const postRepository: Repository<Post> = appDataSource.getRepository(Post);
+    const shiftRepository: Repository<Shift> = appDataSource.getRepository(Shift);
+    const [posts, shifts] = await Promise.all([
+        postRepository.find({ order: { postedAt: "DESC" } }),
+        shiftRepository
+            .createQueryBuilder("shift")
+            .leftJoinAndSelect("shift.cast", "cast")
+            .where("shift.sourcePostId IS NOT NULL")
+            .orderBy("shift.date", "DESC")
+            .addOrderBy("shift.castId", "ASC")
+            .getMany(),
+    ]);
+
+    const shiftOrder: Record<ShiftSlot, number> = {
+        [ShiftSlot.NIGHT]: 1,
+        [ShiftSlot.EVENING]: 2,
+        [ShiftSlot.OPEN]: 3,
+    };
+    const dayLabels: Record<string, string> = {
+        Sun: "日",
+        Mon: "月",
+        Tue: "火",
+        Wed: "水",
+        Thu: "木",
+        Fri: "金",
+        Sat: "土",
+    };
+    const shiftsByPost = new Map<string, PostManagementSummary["shifts"]>();
+
+    for (const shift of shifts) {
+        if (!shift.sourcePostId) {
+            continue;
+        }
+
+        const postShifts = shiftsByPost.get(shift.sourcePostId) ?? [];
+        let usage = postShifts.find(
+            (item) => item.date === shift.date && item.shift === shift.shift,
+        );
+        if (!usage) {
+            const date = new Date(`${shift.date}T00:00:00+09:00`);
+            const dayOfWeek = date.toLocaleDateString("en-US", {
+                weekday: "short",
+                timeZone: "Asia/Tokyo",
+            });
+            usage = {
+                date: shift.date,
+                dayOfWeek: dayLabels[dayOfWeek] ?? dayOfWeek,
+                shift: shift.shift,
+                casts: [],
+            };
+            postShifts.push(usage);
+            shiftsByPost.set(shift.sourcePostId, postShifts);
+        }
+        usage.casts.push({ id: shift.castId, name: shift.cast.name });
+    }
+
+    for (const postShifts of shiftsByPost.values()) {
+        postShifts.sort((a, b) => {
+            const dateComparison = b.date.localeCompare(a.date);
+            return dateComparison !== 0
+                ? dateComparison
+                : shiftOrder[a.shift] - shiftOrder[b.shift];
+        });
+    }
+
+    return posts.map((post) => ({
+        id: post.id,
+        postedAt: post.postedAt,
+        isDeleted: post.isDeleted,
+        showInGallery: post.showInGallery,
+        contentType: post.contentType,
+        shiftSource: post.shiftSource,
+        taggedCasts: [...(post.castTags ?? [])]
+            .sort((a, b) => a.order - b.order)
+            .map((tag) => ({
+                id: tag.cast.id,
+                name: tag.cast.name,
+                type: tag.cast.type,
+                order: tag.order,
+            })),
+        shifts: shiftsByPost.get(post.id) ?? [],
+    }));
 }
 
 /**

--- a/app/tweet-tagger/src/services/shiftService.ts
+++ b/app/tweet-tagger/src/services/shiftService.ts
@@ -2,7 +2,14 @@ import "server-only";
 import "reflect-metadata";
 import { initializeDatabase, appDataSource } from "../data-source";
 import { Post, Repository, Shift } from "@iba-cast-gallery/dao";
-import { ShiftSlot, ShiftSourceStatus, CastType, ShiftGroup } from "@iba-cast-gallery/types";
+import {
+    ShiftSlot,
+    ShiftSourceStatus,
+    CastType,
+    PostContentType,
+} from "@iba-cast-gallery/types";
+import type { ShiftGroup, ShiftPostCandidate } from "@iba-cast-gallery/types";
+import { inferShiftFromPostedAt } from "utils/shift";
 import logger from "../logger";
 
 const SHIFT_LABEL: Record<ShiftSlot, string> = {
@@ -15,6 +22,88 @@ const DAY_LABEL: Record<string, string> = {
     Mon: "月", Tue: "火", Wed: "水", Thu: "木",
     Fri: "金", Sat: "土", Sun: "日",
 };
+
+const SHIFT_TARGET_TIME: Record<ShiftSlot, string> = {
+    [ShiftSlot.OPEN]: "12:00:00",
+    [ShiftSlot.EVENING]: "17:30:00",
+    [ShiftSlot.NIGHT]: "19:00:00",
+};
+
+const SHIFT_CANDIDATE_LIMIT = 8;
+const SHIFT_CANDIDATE_QUERY_LIMIT = 40;
+
+/**
+ * 未登録シフトの情報源候補を、同じ日本時間の日付に投稿された
+ * 未使用のギャラリーポストから近い順で取得する。
+ */
+export async function getShiftPostCandidates(
+    date: string,
+    slot: ShiftSlot,
+): Promise<ShiftPostCandidate[]> {
+    await initializeDatabase();
+
+    const target = new Date(`${date}T${SHIFT_TARGET_TIME[slot]}+09:00`);
+    const dayStart = new Date(`${date}T00:00:00+09:00`);
+    const nextDayStart = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
+    const postRepository: Repository<Post> = appDataSource.getRepository(Post);
+
+    // content_type + posted_at の既存複合インデックスを使えるよう、
+    // 日付範囲で先に候補を限定してからアプリ側で距離順に並べる。
+    const posts = await postRepository
+        .createQueryBuilder("post")
+        .leftJoinAndSelect("post.castTags", "castTag")
+        .leftJoinAndSelect("castTag.cast", "cast")
+        .where("post.contentType = :contentType", {
+            contentType: PostContentType.GALLERY,
+        })
+        .andWhere("post.postedAt >= :dayStart", {
+            dayStart: dayStart.toISOString(),
+        })
+        .andWhere("post.postedAt < :nextDayStart", {
+            nextDayStart: nextDayStart.toISOString(),
+        })
+        .andWhere("post.isDeleted = false")
+        .andWhere("(post.showInGallery = true OR castTag.postId IS NOT NULL)")
+        .andWhere("post.shiftSource IS NULL")
+        .andWhere("post.excludeFromShiftRegistration = false")
+        .orderBy("post.postedAt", "DESC")
+        .take(SHIFT_CANDIDATE_QUERY_LIMIT)
+        .getMany();
+
+    return posts
+        .map((post): ShiftPostCandidate | null => {
+            const inferredShift = inferShiftFromPostedAt(post.postedAt);
+            const postedAt = new Date(post.postedAt);
+            if (!inferredShift || Number.isNaN(postedAt.getTime())) {
+                return null;
+            }
+
+            return {
+                id: post.id,
+                postedAt: post.postedAt,
+                inferredShift: inferredShift.slot,
+                differenceMinutes: Math.round(
+                    Math.abs(postedAt.getTime() - target.getTime()) / 60000,
+                ),
+                taggedCasts: [...(post.castTags ?? [])]
+                    .sort((a, b) => a.order - b.order)
+                    .map((tag) => ({
+                        id: tag.cast.id,
+                        name: tag.cast.name,
+                        order: tag.order,
+                    })),
+            };
+        })
+        .filter((candidate): candidate is ShiftPostCandidate => candidate !== null)
+        .sort((a, b) => {
+            const slotComparison =
+                Number(b.inferredShift === slot) - Number(a.inferredShift === slot);
+            return slotComparison !== 0
+                ? slotComparison
+                : a.differenceMinutes - b.differenceMinutes;
+        })
+        .slice(0, SHIFT_CANDIDATE_LIMIT);
+}
 
 /**
  * 指定日・シフトの記録を取得する

--- a/app/tweet-tagger/src/services/shiftService.ts
+++ b/app/tweet-tagger/src/services/shiftService.ts
@@ -66,11 +66,18 @@ export async function saveShifts(
                     shiftSource: ShiftSourceStatus.PENDING,
                 });
                 logger.info({ sourcePostId }, "シフト元ポスト新規登録");
-            } else if (existing.shiftSource !== ShiftSourceStatus.DONE) {
+            } else {
                 await postRepository.update(sourcePostId, {
-                    shiftSource: ShiftSourceStatus.PENDING,
+                    shiftSource:
+                        existing.shiftSource === ShiftSourceStatus.DONE
+                            ? ShiftSourceStatus.DONE
+                            : ShiftSourceStatus.PENDING,
+                    excludeFromShiftRegistration: false,
                 });
-                logger.info({ sourcePostId }, "シフト元ポスト shift_source=pending に更新");
+                logger.info(
+                    { sourcePostId },
+                    "シフト元ポストの登録状態を更新",
+                );
             }
         }
 
@@ -119,11 +126,18 @@ export async function updateShiftSource(
                 shiftSource: ShiftSourceStatus.PENDING,
             });
             logger.info({ sourcePostId }, "シフト元ポスト新規登録（ソース後付け）");
-        } else if (existing.shiftSource !== ShiftSourceStatus.DONE) {
+        } else {
             await postRepository.update(sourcePostId, {
-                shiftSource: ShiftSourceStatus.PENDING,
+                shiftSource:
+                    existing.shiftSource === ShiftSourceStatus.DONE
+                        ? ShiftSourceStatus.DONE
+                        : ShiftSourceStatus.PENDING,
+                excludeFromShiftRegistration: false,
             });
-            logger.info({ sourcePostId }, "シフト元ポスト shift_source=pending に更新（ソース後付け）");
+            logger.info(
+                { sourcePostId },
+                "シフト元ポストの登録状態を更新（ソース後付け）",
+            );
         }
 
         // ② shifts の source_post_id を更新

--- a/e2e/post-shift-registration-flow.spec.ts
+++ b/e2e/post-shift-registration-flow.spec.ts
@@ -6,6 +6,7 @@ const ADMIN_URL = "http://localhost:3001";
 const GALLERY_URL = "http://localhost:3000";
 const COMBINED_POST_ID = "11646878510085046272";
 const SHIFT_ONLY_POST_ID = "11647271096939446272";
+const GALLERY_ONLY_POST_ID = "11647610138419446272";
 const COMBINED_DATE = "2098-11-01";
 const SHIFT_ONLY_DATE = "2098-11-02";
 
@@ -72,6 +73,9 @@ if (!taggedCast || !boardOnlyCast) {
                 SHIFT_ONLY_DATE,
                 "night",
             );
+            await page.request.delete(
+                `${ADMIN_URL}/api/posts/${GALLERY_ONLY_POST_ID}`,
+            );
         });
 
         test.afterEach(async ({ page }) => {
@@ -86,6 +90,9 @@ if (!taggedCast || !boardOnlyCast) {
                 SHIFT_ONLY_POST_ID,
                 SHIFT_ONLY_DATE,
                 "night",
+            );
+            await page.request.delete(
+                `${ADMIN_URL}/api/posts/${GALLERY_ONLY_POST_ID}`,
             );
         });
 
@@ -232,6 +239,108 @@ if (!taggedCast || !boardOnlyCast) {
             await expect(
                 page.getByTestId(`tweet-container-${SHIFT_ONLY_POST_ID}`),
             ).not.toBeVisible();
+        });
+
+        test("ギャラリーのシフト未登録を絞り込み、対象外へ切り替えられる", async ({
+            page,
+        }) => {
+            const registerResponse = await page.request.post(
+                `${ADMIN_URL}/api/posts`,
+                {
+                    data: {
+                        post: {
+                            id: GALLERY_ONLY_POST_ID,
+                            postedAt: "2098-11-03T10:00:00.000Z",
+                            isDeleted: false,
+                            showInGallery: true,
+                            contentType: "gallery",
+                            shiftSource: null,
+                            excludeFromShiftRegistration: false,
+                            castTags: [
+                                {
+                                    castid: taggedCast.id,
+                                    order: 1,
+                                },
+                            ],
+                        },
+                    },
+                },
+            );
+            expect(registerResponse.status()).toBe(201);
+
+            await Promise.all([
+                page.goto(`${ADMIN_URL}/posts`),
+                page.waitForResponse((response: any) =>
+                    response.url().includes("/api/post-summaries"),
+                ),
+            ]);
+            await page
+                .getByTestId("post-search-input")
+                .fill(GALLERY_ONLY_POST_ID);
+            await page.getByRole("combobox", { name: "登録用途" }).click();
+            await page
+                .getByRole("option", {
+                    name: "ギャラリー（シフト未登録）",
+                })
+                .click();
+
+            const summary = page.getByTestId(
+                `post-summary-${GALLERY_ONLY_POST_ID}`,
+            );
+            await expect(summary).toBeVisible();
+            await expect(
+                summary.getByText("シフト未登録", { exact: true }),
+            ).toBeVisible();
+
+            const excludeResponsePromise = page.waitForResponse(
+                (response) =>
+                    response.url() ===
+                        `${ADMIN_URL}/api/posts/${GALLERY_ONLY_POST_ID}` &&
+                    response.request().method() === "PATCH",
+            );
+            await page
+                .getByTestId(
+                    `post-shift-exclusion-toggle-${GALLERY_ONLY_POST_ID}`,
+                )
+                .click();
+            expect((await excludeResponsePromise).status()).toBe(200);
+            await expect(summary).not.toBeAttached();
+
+            await page.getByRole("combobox", { name: "登録用途" }).click();
+            await page.getByRole("option", { name: "すべて" }).click();
+            await expect(summary).toBeVisible();
+            await expect(
+                summary.getByText("シフト登録対象外", { exact: true }),
+            ).toBeVisible();
+
+            const postResponse = await page.request.get(
+                `${ADMIN_URL}/api/posts/${GALLERY_ONLY_POST_ID}`,
+            );
+            expect(postResponse.ok()).toBeTruthy();
+            expect(
+                (await postResponse.json()).excludeFromShiftRegistration,
+            ).toBe(true);
+
+            const restoreResponsePromise = page.waitForResponse(
+                (response) =>
+                    response.url() ===
+                        `${ADMIN_URL}/api/posts/${GALLERY_ONLY_POST_ID}` &&
+                    response.request().method() === "PATCH",
+            );
+            await page
+                .getByTestId(
+                    `post-shift-exclusion-toggle-${GALLERY_ONLY_POST_ID}`,
+                )
+                .click();
+            expect((await restoreResponsePromise).status()).toBe(200);
+
+            await page.getByRole("combobox", { name: "登録用途" }).click();
+            await page
+                .getByRole("option", {
+                    name: "ギャラリー（シフト未登録）",
+                })
+                .click();
+            await expect(summary).toBeVisible();
         });
 
         test("写真タグが出勤キャストに含まれない不整合なリクエストを拒否する", async ({

--- a/e2e/post-shift-registration-flow.spec.ts
+++ b/e2e/post-shift-registration-flow.spec.ts
@@ -166,6 +166,30 @@ if (!taggedCast || !boardOnlyCast) {
             expect(shift.castIds.sort()).toEqual(
                 [taggedCast.id, boardOnlyCast.id].sort(),
             );
+
+            await Promise.all([
+                page.goto(`${ADMIN_URL}/posts`),
+                page.waitForResponse((response: any) =>
+                    response.url().includes("/api/post-summaries"),
+                ),
+            ]);
+            await page.getByTestId("post-search-input").fill(COMBINED_POST_ID);
+
+            const summary = page.getByTestId(`post-summary-${COMBINED_POST_ID}`);
+            await expect(summary).toBeVisible();
+            await expect(summary.getByText("ギャラリー", { exact: true })).toBeVisible();
+            await expect(summary.getByText("シフト", { exact: true })).toBeVisible();
+            const shiftSummary = summary.getByTestId(
+                `post-shift-${COMBINED_POST_ID}-${COMBINED_DATE}-evening`,
+            );
+            await expect(shiftSummary).toContainText(COMBINED_DATE);
+            await expect(shiftSummary).toContainText("夕方");
+            await expect(shiftSummary).toContainText(taggedCast.name);
+            await expect(shiftSummary).toContainText(boardOnlyCast.name);
+
+            await page.getByRole("combobox", { name: "登録用途" }).click();
+            await page.getByRole("option", { name: "シフト" }).click();
+            await expect(summary).toBeVisible();
         });
 
         test("シフトだけ登録したポストはギャラリータグを持たず非公開になる", async ({

--- a/e2e/post-shift-registration-flow.spec.ts
+++ b/e2e/post-shift-registration-flow.spec.ts
@@ -195,7 +195,9 @@ if (!taggedCast || !boardOnlyCast) {
             await expect(shiftSummary).toContainText(boardOnlyCast.name);
 
             await page.getByRole("combobox", { name: "登録用途" }).click();
-            await page.getByRole("option", { name: "シフト" }).click();
+            await page
+                .getByRole("option", { name: "シフト", exact: true })
+                .click();
             await expect(summary).toBeVisible();
         });
 

--- a/e2e/shift-flow.spec.ts
+++ b/e2e/shift-flow.spec.ts
@@ -89,6 +89,44 @@ if (!testCast) {
             await expect(matchingRow).toBeVisible();
         });
 
+        test('未登録枠を検出し、対象日時を登録フォームへ引き継げること', async ({ page }) => {
+            for (const shift of ['open', 'evening', 'night']) {
+                await page.request.post(`${ADMIN_URL}/api/shifts`, {
+                    data: { date: TEST_DATE, shift, castIds: [] },
+                });
+            }
+
+            await Promise.all([
+                page.goto(`${ADMIN_URL}/shifts`),
+                page.waitForResponse((res: any) => res.url().includes('/api/shifts/list')),
+                page.waitForResponse((res: any) => res.url().includes('/api/shifts?date=')),
+            ]);
+
+            await page.getByTestId('shift-coverage-from').fill(TEST_DATE);
+            await page.getByTestId('shift-coverage-to').fill(TEST_DATE);
+
+            await expect(page.getByTestId(`shift-missing-${TEST_DATE}-open`)).toBeVisible();
+            await expect(page.getByTestId(`shift-missing-${TEST_DATE}-evening`)).toBeVisible();
+            await expect(page.getByTestId(`shift-missing-${TEST_DATE}-night`)).toBeVisible();
+
+            const selectedShiftResponse = page.waitForResponse((res: any) =>
+                res.url().includes(`/api/shifts?date=${TEST_DATE}&shift=evening`),
+            );
+            await page.getByTestId(`shift-missing-${TEST_DATE}-evening`).click();
+            await selectedShiftResponse;
+
+            await expect(page.getByTestId('shift-date-input')).toHaveValue('2099/11/01');
+            await expect(page.getByRole('button', { name: '夕方', exact: true })).toHaveAttribute(
+                'aria-pressed',
+                'true',
+            );
+
+            // 水曜は定休日として欠損扱いにしない
+            await page.getByTestId('shift-coverage-from').fill('2099-11-04');
+            await page.getByTestId('shift-coverage-to').fill('2099-11-04');
+            await expect(page.getByText('この期間は3枠すべて登録済みです')).toBeVisible();
+        });
+
         test('ソースツイートを登録するとリンクが表示され、クリックでダイアログにツイートが表示されること', async ({ page }) => {
             const tweetId = '1954740195934474563';
 

--- a/e2e/shift-flow.spec.ts
+++ b/e2e/shift-flow.spec.ts
@@ -5,6 +5,7 @@ const ADMIN_URL = 'http://localhost:3001';
 
 // 運用データや他テストと衝突しない遠い未来の固定日付
 const TEST_DATE = '2099-11-01';
+const SHIFT_CANDIDATE_POST_ID = '11701463500000000001';
 
 async function login(page: any) {
     await page.request.post(`${ADMIN_URL}/api/auth/e2e-login`);
@@ -109,10 +110,23 @@ if (!testCast) {
             await expect(page.getByTestId(`shift-missing-${TEST_DATE}-evening`)).toBeVisible();
             await expect(page.getByTestId(`shift-missing-${TEST_DATE}-night`)).toBeVisible();
 
+            const candidateResponse = page.waitForResponse((res: any) =>
+                res.url().includes(
+                    `/api/posts/shift-candidates?date=${TEST_DATE}&shift=evening`,
+                ),
+            );
+            await page.getByTestId(`shift-missing-${TEST_DATE}-evening`).click();
+            expect((await candidateResponse).status()).toBe(200);
+
+            await expect(page.getByTestId('shift-candidate-dialog')).toBeVisible();
+            await expect(
+                page.getByText('この日に利用できる既存ポストは見つかりませんでした。'),
+            ).toBeVisible();
+
             const selectedShiftResponse = page.waitForResponse((res: any) =>
                 res.url().includes(`/api/shifts?date=${TEST_DATE}&shift=evening`),
             );
-            await page.getByTestId(`shift-missing-${TEST_DATE}-evening`).click();
+            await page.getByTestId('shift-candidate-create-new').click();
             await selectedShiftResponse;
 
             await expect(page.getByTestId('shift-date-input')).toHaveValue('2099/11/01');
@@ -125,6 +139,80 @@ if (!testCast) {
             await page.getByTestId('shift-coverage-from').fill('2099-11-04');
             await page.getByTestId('shift-coverage-to').fill('2099-11-04');
             await expect(page.getByText('この期間は3枠すべて登録済みです')).toBeVisible();
+        });
+
+        test('未登録枠へ近い時間帯の既存ポストを選べること', async ({ page }) => {
+            for (const shift of ['open', 'evening', 'night']) {
+                await page.request.post(`${ADMIN_URL}/api/shifts`, {
+                    data: { date: TEST_DATE, shift, castIds: [] },
+                });
+            }
+            await page.request.delete(
+                `${ADMIN_URL}/api/posts/${SHIFT_CANDIDATE_POST_ID}`,
+            );
+
+            const registerResponse = await page.request.post(`${ADMIN_URL}/api/posts`, {
+                data: {
+                    post: {
+                        id: SHIFT_CANDIDATE_POST_ID,
+                        postedAt: '2099-11-01T08:35:00.000Z',
+                        isDeleted: false,
+                        showInGallery: true,
+                        contentType: 'gallery',
+                        shiftSource: null,
+                        excludeFromShiftRegistration: false,
+                        castTags: [{ castid: testCast.id, order: 1 }],
+                    },
+                },
+            });
+            expect(registerResponse.status()).toBe(201);
+
+            try {
+                await Promise.all([
+                    page.goto(`${ADMIN_URL}/shifts`),
+                    page.waitForResponse((res: any) => res.url().includes('/api/shifts/list')),
+                    page.waitForResponse((res: any) => res.url().includes('/api/shifts?date=')),
+                ]);
+
+                await page.getByTestId('shift-coverage-from').fill(TEST_DATE);
+                await page.getByTestId('shift-coverage-to').fill(TEST_DATE);
+
+                const candidateResponse = page.waitForResponse((res: any) =>
+                    res.url().includes(
+                        `/api/posts/shift-candidates?date=${TEST_DATE}&shift=evening`,
+                    ),
+                );
+                await page.getByTestId(`shift-missing-${TEST_DATE}-evening`).click();
+                expect((await candidateResponse).status()).toBe(200);
+
+                const candidate = page.getByTestId(
+                    `shift-candidate-${SHIFT_CANDIDATE_POST_ID}`,
+                );
+                await expect(candidate).toBeVisible();
+                await expect(candidate).toContainText('17:35投稿');
+                await expect(candidate).toContainText('夕方');
+                await expect(candidate).toContainText(testCast.name);
+
+                const selectedShiftResponse = page.waitForResponse((res: any) =>
+                    res.url().includes(`/api/shifts?date=${TEST_DATE}&shift=evening`),
+                );
+                await page
+                    .getByTestId(`shift-candidate-select-${SHIFT_CANDIDATE_POST_ID}`)
+                    .click();
+                await selectedShiftResponse;
+
+                await expect(page.getByTestId('shift-date-input')).toHaveValue('2099/11/01');
+                await expect(page.getByTestId('shift-tweet-url-input')).toHaveValue(
+                    SHIFT_CANDIDATE_POST_ID,
+                );
+                await expect(
+                    page.getByRole('button', { name: '夕方', exact: true }),
+                ).toHaveAttribute('aria-pressed', 'true');
+            } finally {
+                await page.request.delete(
+                    `${ADMIN_URL}/api/posts/${SHIFT_CANDIDATE_POST_ID}`,
+                );
+            }
         });
 
         test('ソースツイートを登録するとリンクが表示され、クリックでダイアログにツイートが表示されること', async ({ page }) => {

--- a/e2e/tweet-flow.spec.ts
+++ b/e2e/tweet-flow.spec.ts
@@ -72,9 +72,22 @@ test.describe('Tweet Tagger and Gallery Flow', () => {
 
         await expect(page.getByTestId('tweet-id-input')).toBeEmpty();
 
-        await page.goto('http://localhost:3001/posts');
+        await Promise.all([
+            page.goto('http://localhost:3001/posts'),
+            page.waitForResponse((response) =>
+                response.url().includes('/api/post-summaries')
+            ),
+        ]);
+
+        // 一覧は軽量なサマリーのみを表示し、検索後に必要なポストだけ確認できること
+        await page.getByTestId('post-search-input').fill(tweetId);
+        const postSummary = page.getByTestId(`post-summary-${tweetId}`);
+        await expect(postSummary).toBeVisible();
+        await expect(postSummary.getByText('ギャラリー', { exact: true })).toBeVisible();
 
         const tweetContainer = page.getByTestId(`tweet-container-${tweetId}`);
+        await expect(tweetContainer).not.toBeAttached();
+        await page.getByTestId(`post-preview-toggle-${tweetId}`).click();
         await expect(tweetContainer).toBeVisible();
 
         await expect(tweetContainer.getByTestId('cast-tag-1')).toHaveText('メノウ');

--- a/e2e/tweet-flow.spec.ts
+++ b/e2e/tweet-flow.spec.ts
@@ -79,16 +79,17 @@ test.describe('Tweet Tagger and Gallery Flow', () => {
             ),
         ]);
 
-        // 一覧は軽量なサマリーのみを表示し、検索後に必要なポストだけ確認できること
+        // 一覧は画面に入ったポストを自動で遅延表示すること
         await page.getByTestId('post-search-input').fill(tweetId);
         const postSummary = page.getByTestId(`post-summary-${tweetId}`);
         await expect(postSummary).toBeVisible();
         await expect(postSummary.getByText('ギャラリー', { exact: true })).toBeVisible();
 
         const tweetContainer = page.getByTestId(`tweet-container-${tweetId}`);
-        await expect(tweetContainer).not.toBeAttached();
-        await page.getByTestId(`post-preview-toggle-${tweetId}`).click();
-        await expect(tweetContainer).toBeVisible();
+        await expect(tweetContainer).toBeVisible({ timeout: 15000 });
+        await expect(
+            page.getByTestId(`post-preview-toggle-${tweetId}`),
+        ).toHaveText('ポストを閉じる');
 
         await expect(tweetContainer.getByTestId('cast-tag-1')).toHaveText('メノウ');
         await expect(tweetContainer.getByTestId('cast-tag-2')).toHaveText('リシア');

--- a/packages/dao/src/entities/Post.ts
+++ b/packages/dao/src/entities/Post.ts
@@ -47,6 +47,13 @@ export class Post {
   })
   shiftSource: ShiftSourceStatus | null;
 
+  @Column({
+    name: "exclude_from_shift_registration",
+    type: "boolean",
+    default: false,
+  })
+  excludeFromShiftRegistration: boolean;
+
   /**
    * キャストのタグ付情報
    */

--- a/packages/dao/src/migrations/1786060800000-addPostShiftRegistrationExclusion.ts
+++ b/packages/dao/src/migrations/1786060800000-addPostShiftRegistrationExclusion.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * ギャラリーポストを「シフト登録候補」から恒久的に除外できるようにする。
+ * 既存ポストはすべて候補のまま維持する。
+ */
+export class AddPostShiftRegistrationExclusion1786060800000
+    implements MigrationInterface
+{
+    private readonly schema = process.env.DB_SCHEMA ?? "public";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "${this.schema}"."posts"
+            ADD COLUMN "exclude_from_shift_registration" boolean NOT NULL DEFAULT false
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "${this.schema}"."posts"
+            DROP COLUMN "exclude_from_shift_registration"
+        `);
+    }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,6 @@ export { PostContentType } from "./post";
 export type { PostDto, PostManagementSummary, PostWithCastsDto } from "./post";
 export type { PostRegistrationRequest, PostRegistrationResult, ShiftRegistrationInput } from "./postRegistration";
 export { ShiftSlot, ShiftSourceStatus } from "./shift";
-export type { ShiftDto, ShiftGroup } from "./shift";
+export type { ShiftDto, ShiftGroup, ShiftPostCandidate } from "./shift";
 export { EventType } from "./event";
 export type { EventDto } from "./event";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,7 +1,7 @@
 export { CastType } from "./cast";
 export type { CastDto } from "./cast";
 export { PostContentType } from "./post";
-export type { PostDto, PostWithCastsDto } from "./post";
+export type { PostDto, PostManagementSummary, PostWithCastsDto } from "./post";
 export type { PostRegistrationRequest, PostRegistrationResult, ShiftRegistrationInput } from "./postRegistration";
 export { ShiftSlot, ShiftSourceStatus } from "./shift";
 export type { ShiftDto, ShiftGroup } from "./shift";

--- a/packages/types/src/post.ts
+++ b/packages/types/src/post.ts
@@ -33,6 +33,7 @@ export interface PostManagementSummary {
     showInGallery: boolean;
     contentType: PostContentType;
     shiftSource: ShiftSourceStatus | null;
+    excludeFromShiftRegistration: boolean;
     taggedCasts: {
         id: number;
         name: string;

--- a/packages/types/src/post.ts
+++ b/packages/types/src/post.ts
@@ -1,4 +1,5 @@
-import {CastDto} from "./cast";
+import { CastDto, CastType } from "./cast";
+import { ShiftSlot, ShiftSourceStatus } from "./shift";
 
 export enum PostContentType {
     GALLERY = "gallery",
@@ -22,5 +23,26 @@ export interface PostWithCastsDto {
     taggedCasts: {
         order: number;
         cast: CastDto;
+    }[];
+}
+
+export interface PostManagementSummary {
+    id: string;
+    postedAt: string;
+    isDeleted: boolean;
+    showInGallery: boolean;
+    contentType: PostContentType;
+    shiftSource: ShiftSourceStatus | null;
+    taggedCasts: {
+        id: number;
+        name: string;
+        type: CastType;
+        order: number;
+    }[];
+    shifts: {
+        date: string;
+        dayOfWeek: string;
+        shift: ShiftSlot;
+        casts: { id: number; name: string }[];
     }[];
 }

--- a/packages/types/src/shift.ts
+++ b/packages/types/src/shift.ts
@@ -24,3 +24,11 @@ export interface ShiftGroup {
     casts: { id: number; name: string; type: string }[];
     sourcePostId: string | null;
 }
+
+export interface ShiftPostCandidate {
+    id: string;
+    postedAt: string;
+    inferredShift: ShiftSlot;
+    differenceMinutes: number;
+    taggedCasts: { id: number; name: string; order: number }[];
+}


### PR DESCRIPTION
## 概要

管理画面の登録済みポスト一覧を、Gallery・BLOG・Shiftを横断して確認できる運用ビューへ改善しました。
あわせて、シフト登録漏れを見つけ、近い時間帯の既存ポストを再利用するか、新しいポストから補完できる導線を追加しています。

## 主な変更

### 登録済みポスト管理

- Gallery・BLOG・Shiftの用途、公開/削除状態、キャストタグ、シフト日時・時間帯を統合表示
- ポストID・キャスト名・シフト日付による検索
- 用途・公開状態・キャストによるフィルターとページネーション
- 「ギャラリー（シフト未登録）」フィルター
- シフト未登録／シフト登録対象外の状態表示
- 今後シフト登録しない投稿を対象外にできる可逆な操作
  - 状態はDBへ永続保存
  - 後からシフトへ登録した場合は対象外フラグを自動解除
- 各カードが画面付近へ来た時点でX/BLOGポストを自動表示
  - Intersection Observerと動的importで、画面外のポスト・画像は遅延読み込み
  - 表示後もカード単位で閉じる／再表示が可能

### シフト入力漏れの補完

- 初期表示は直近14日、期間変更は最大366日
- 水曜を定休日として対象外
- 各日のオープン・夕方・夜の不足枠を表示
- 不足枠を押すと、同じ日の未使用ギャラリーポストを候補表示
  - 削除済み、シフト使用済み、シフト登録対象外は除外
  - 選択中の時間帯に一致するポストを優先し、基準時刻との差が近い順に最大8件
  - 候補ごとに投稿時刻・時間帯・キャストタグを表示
  - 内容確認時だけXポストを読み込む
- 候補を選ぶと、日付・時間帯・ポストIDを登録フォームへ引き継ぐ
- 候補がない場合や該当しない場合は「新しいポストを登録」から従来のURL/ID入力へ進める
- 候補検索は既存の `content_type, posted_at` 複合インデックスを利用できる日付範囲クエリ

### API・テスト

- 管理画面向けポスト集約API
- シフト情報源候補API `GET /api/posts/shift-candidates`
- 上記フローのE2Eテスト追加・更新
- `posts.exclude_from_shift_registration`追加マイグレーション

## 検証

- Node.js 24.18.0
- TypeScript型チェック: 成功
- Unit Test: 3件成功
- Production Build（Docker E2E環境）: 成功
- 変更直結E2E: 6件成功
- Playwright E2E全体: 77件成功（1 worker）
- `git diff --check`: 成功
